### PR TITLE
feat(options): add debug symbol separation with --debug-dir flag

### DIFF
--- a/cmd/yap/command/build.go
+++ b/cmd/yap/command/build.go
@@ -254,4 +254,8 @@ func init() {
 	// CROSS-COMPILATION FLAGS
 	buildCmd.Flags().StringVarP(&project.TargetArch,
 		"target-arch", "t", "", "Target architecture for cross-compilation (e.g., arm64, armv7, x86_64)")
+
+	// DEBUG SYMBOL FLAGS
+	buildCmd.Flags().StringVarP(&project.DebugDir,
+		"debug-dir", "", "", "Output directory for separated debug symbols (.build-id structure for debuginfod)")
 }

--- a/pkg/binary/strip.go
+++ b/pkg/binary/strip.go
@@ -3,10 +3,109 @@ package binary //nolint:revive // intentional name; conflicts with stdlib encodi
 
 import (
 	"context"
+	"debug/elf"
 	"os"
+	"path/filepath"
 
+	"github.com/M0Rf30/yap/v2/pkg/files"
+	"github.com/M0Rf30/yap/v2/pkg/logger"
 	"github.com/M0Rf30/yap/v2/pkg/shell"
 )
+
+// ReadBuildID reads the ELF build-id from the given binary.
+// Returns an empty string if the binary has no build-id.
+func ReadBuildID(path string) string {
+	file, err := elf.Open(path)
+	if err != nil {
+		return ""
+	}
+
+	defer func() {
+		_ = file.Close()
+	}()
+
+	for _, section := range file.Sections {
+		if section.Name != ".note.gnu.build-id" {
+			continue
+		}
+
+		data, err := section.Data()
+		if err != nil || len(data) < 16 {
+			return ""
+		}
+
+		// ELF note format: namesz(4) + descsz(4) + type(4) + name + desc
+		nameSize := file.ByteOrder.Uint32(data[0:4])
+		descSize := file.ByteOrder.Uint32(data[4:8])
+
+		nameEnd := 12 + nameSize
+		if nameEnd%4 != 0 {
+			nameEnd += 4 - nameEnd%4
+		}
+
+		descEnd := nameEnd + descSize
+		if int(descEnd) > len(data) {
+			return ""
+		}
+
+		desc := data[nameEnd:descEnd]
+		hexStr := make([]byte, len(desc)*2)
+
+		const hexChars = "0123456789abcdef"
+
+		for i, b := range desc {
+			hexStr[i*2] = hexChars[b>>4]
+			hexStr[i*2+1] = hexChars[b&0x0f]
+		}
+
+		return string(hexStr)
+	}
+
+	return ""
+}
+
+// SeparateDebugInfo extracts debug information from the binary into a separate
+// file organized by build-id, then adds a .gnu_debuglink to the original binary.
+// The debug file is stored at <debugDir>/.build-id/<prefix>/<suffix>.debug.
+// Returns the path to the debug file, or empty string if no build-id was found.
+func SeparateDebugInfo(binary, debugDir string) (string, error) {
+	buildID := ReadBuildID(binary)
+	if buildID == "" || len(buildID) < 3 {
+		return "", nil
+	}
+
+	prefix := buildID[:2]
+	suffix := buildID[2:]
+	debugSubDir := filepath.Join(debugDir, ".build-id", prefix)
+
+	err := files.ExistsMakeDir(debugSubDir)
+	if err != nil {
+		return "", err
+	}
+
+	debugFile := filepath.Join(debugSubDir, suffix+".debug")
+
+	// Use cross-compilation objcopy if OBJCOPY environment variable is set
+	objcopyCmd := os.Getenv("OBJCOPY")
+	if objcopyCmd == "" {
+		objcopyCmd = "objcopy"
+	}
+
+	ctx := context.Background()
+
+	err = shell.Exec(ctx, false, "", objcopyCmd, "--only-keep-debug", binary, debugFile)
+	if err != nil {
+		return "", err
+	}
+
+	err = shell.Exec(ctx, false, "", objcopyCmd, "--add-gnu-debuglink="+debugFile, binary)
+	if err != nil {
+		logger.Warn("failed to add debuglink",
+			"binary", binary, "error", err)
+	}
+
+	return debugFile, nil
+}
 
 // StripFile removes debugging symbols from a binary file.
 // It respects the STRIP environment variable for cross-compilation support.

--- a/pkg/builders/pacman/makepkg.go
+++ b/pkg/builders/pacman/makepkg.go
@@ -22,6 +22,7 @@ import (
 	"github.com/M0Rf30/yap/v2/pkg/files"
 	"github.com/M0Rf30/yap/v2/pkg/i18n"
 	"github.com/M0Rf30/yap/v2/pkg/logger"
+	"github.com/M0Rf30/yap/v2/pkg/options"
 	"github.com/M0Rf30/yap/v2/pkg/pkgbuild"
 )
 
@@ -130,6 +131,13 @@ func (m *Pkg) PrepareFakeroot(artifactsPath string, targetArch string) error {
 		".BUILDINFO"), tmpl)
 	if err != nil {
 		return err
+	}
+
+	if m.PKGBUILD.StripEnabled {
+		err = options.Strip(m.PKGBUILD.PackageDir)
+		if err != nil {
+			return err
+		}
 	}
 
 	var mtreeEntries []*files.Entry

--- a/pkg/options/strip.go
+++ b/pkg/options/strip.go
@@ -14,6 +14,14 @@ import (
 	"github.com/M0Rf30/yap/v2/pkg/logger"
 )
 
+// debugDir holds the output directory for separated debug symbols.
+var debugDir string
+
+// SetDebugDir sets the output directory for debug symbols.
+func SetDebugDir(dir string) {
+	debugDir = dir
+}
+
 // Strip walks through the directory to process each file.
 func Strip(packageDir string) error {
 	logger.Info(i18n.T("logger.strip.info.stripping_binaries_1"))
@@ -67,6 +75,18 @@ func processFile(binary string, dirEntry fs.DirEntry, err error) error {
 	fileType := files.GetFileType(binary)
 	if fileType == "" || fileType == "ET_NONE" {
 		return err
+	}
+
+	// Separate debug info before stripping, if a debug directory is configured.
+	if debugDir != "" {
+		debugFile, sepErr := binutil.SeparateDebugInfo(binary, debugDir)
+		if sepErr != nil {
+			logger.Warn("failed to separate debug info",
+				"binary", binary, "error", sepErr)
+		} else if debugFile != "" {
+			logger.Info("separated debug info",
+				"binary", binary, "debug", debugFile)
+		}
 	}
 
 	stripFlags, stripLTO := determineStripFlags(fileType, binary)

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -21,6 +21,7 @@ import (
 	"github.com/M0Rf30/yap/v2/pkg/files"
 	"github.com/M0Rf30/yap/v2/pkg/i18n"
 	"github.com/M0Rf30/yap/v2/pkg/logger"
+	"github.com/M0Rf30/yap/v2/pkg/options"
 	"github.com/M0Rf30/yap/v2/pkg/packer"
 	"github.com/M0Rf30/yap/v2/pkg/parser"
 	"github.com/M0Rf30/yap/v2/pkg/pkgbuild"
@@ -63,6 +64,10 @@ var (
 	// Parallel enables parallel dependency resolution and concurrent package building.
 	// When false (default), packages are built sequentially respecting "install" flags.
 	Parallel bool
+	// DebugDir is the output directory for separated debug symbol files.
+	// When set, debug info is extracted from ELF binaries before stripping
+	// and saved in a .build-id directory structure suitable for debuginfod.
+	DebugDir string
 
 	// Global state variables
 	singleProject  bool
@@ -589,6 +594,20 @@ func (mpc *MultipleProject) createPackage(proj *Project) error {
 	err := files.ExistsMakeDir(mpc.Output)
 	if err != nil {
 		return err
+	}
+
+	// Configure debug symbol separation before stripping occurs in PrepareFakeroot.
+	if DebugDir != "" {
+		absDebugDir, absErr := filepath.Abs(DebugDir)
+		if absErr != nil {
+			return absErr
+		}
+
+		if mkErr := files.ExistsMakeDir(absDebugDir); mkErr != nil {
+			return mkErr
+		}
+
+		options.SetDebugDir(absDebugDir)
 	}
 
 	err = proj.PackageManager.PrepareFakeroot(mpc.Output, TargetArch)


### PR DESCRIPTION
Port debuginfod support from v1 to v2. Separates debug info from ELF binaries before stripping using objcopy, organized by build-id for debuginfod integration. Adds ReadBuildID and SeparateDebugInfo to binary package, wires --debug-dir flag through project build chain. Also adds strip call to pacman builder PrepareFakeroot which was missing.