### PR TITLE
feat(builders): add package signing, SBOM, per-format compression, and d changelog support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,22 @@ yap graph <project-path>                       # Show dependency graph
 yap build --skip-sync <project-path>           # Skip dependency sync (faster)
 yap build --cleanbuild <project-path>          # Clean source before build
 yap build --parallel <project-path>            # Enable parallel dep-aware topo-sort (opt-in)
+
+# Signing
+yap build --sign <project>                     # Enable artifact signing (key resolved from flags/env/config/default)
+yap build --sign-key /path/to/private.key # Specify private key path
+yap build --sign-passphrase pass          # Passphrase (use env vars in CI: YAP_SIGN_PASSPHRASE)
+yap build --sign-key-name mykey           # APK key name (.SIGN.RSA.<keyname>.rsa.pub)
+
+# SBOM (Software Bill of Materials)
+yap build --sbom                          # Generate SBOM sidecars next to artifacts
+yap build --sbom-format cyclonedx         # Only CycloneDX 1.5 (default: both)
+yap build --sbom-format spdx              # Only SPDX 2.3
+yap build --sbom-format both              # Both formats (default)
+
+# Compression overrides
+yap build --compression-deb gzip          # DEB compression: zstd|gzip|xz (default: zstd)
+yap build --compression-rpm xz            # RPM compression: zstd|gzip|xz (default: zstd)
 ```
 
 
@@ -331,15 +347,13 @@ The APK builder (`pkg/builders/apk/`) targets Alpine Linux APK compatibility. Cu
 - **PAX Extended Headers**: `APK-TOOLS.checksum.SHA1` per-file headers (`writeFileWithChecksum`) consumed by `apk audit`
 - **`.PKGINFO` Metadata**: name, version, arch, description, license, url, dependencies, conflicts, `size`, `origin`, `builddate`, `datahash` (SHA-256 of `data.tar.gz`)
 - **Dependency Handling**: depends, makedepends, conflicts, provides
+- **RSA Signature Stream** (`.SIGN.RSA.<keyname>.rsa.pub`): PKCS#1 v1.5 SHA1 signature over control.tar.gz, prepended as third concatenated gzip stream — enables `apk add` without `--allow-untrusted`. Implementation: `pkg/signing/rsa.go`.
 
 #### 🚧 In Progress / Planned Features
-1. **RSA Signature Stream** (`.SIGN.RSA.*`) — High Priority
-   - Adds the third concatenated gzip stream required for trusted (non-`--allow-untrusted`) installs
-   - Integration with Alpine signing keys / abuild-keygen
-2. **Optional Extended Metadata** — Low Priority
+1. **Optional Extended Metadata** — Low Priority
    - `commit` (Git commit hash) — currently not emitted
    - Per-file ACL / xattr headers (rare in practice)
-3. **Test Coverage Expansion** — Ongoing
+2. **Test Coverage Expansion** — Ongoing
    - Current: ~70%, target: 85%
 
 #### Testing APK Packages
@@ -427,6 +441,12 @@ yap build arch examples/yap           # Arch Linux
 3. **Package Signing Infrastructure** - RSA signature integration
 
 ### Recent Achievements
+- ✅ **Package signing infrastructure: APK RSA + DEB/RPM/Pacman GPG (2026-05-04)** — Pure-Go via ProtonMail/go-crypto. APK packages now installable without --allow-untrusted; DEB/RPM/Pacman emit detached signature sidecars (.deb.asc/.rpm.asc/.pkg.tar.zst.sig). RPM also supports in-package signatures via rpmpack.SetPGPSigner. Priority: CLI > format env > global env > yap.json > ~/.config/yap/keys/.
+- ✅ **SBOM generation: CycloneDX 1.5 + SPDX 2.3 (2026-05-04)** — Opt-in via --sbom; emits .cdx.json and/or .spdx.json sidecars next to each built artifact. Hand-rolled, no external SBOM library.
+- ✅ **Per-format compression for DEB/RPM (2026-05-04)** — --compression-deb and --compression-rpm flags accept zstd/gzip/xz. APK and Pacman remain format-locked.
+- ✅ **Pacman .INSTALL scriptlets (2026-05-04)** — Full 6-hook parity with DEB/RPM (pre_install, post_install, pre_upgrade, post_upgrade, pre_remove, post_remove). .install file conditionally emitted only when scriptlets are present.
+- ✅ **Changelog support (2026-05-04)** — New PKGBUILD `changelog` field. DEB emits Lintian-compliant `usr/share/doc/<pkg>/changelog.Debian.gz`; Pacman emits `.CHANGELOG`. RPM deferred (rpmpack API gap).
+- ✅ **Builder interface unification (2026-05-04)** — BuildPackage now returns (string, error) across all four builders, enabling post-build pipeline hooks for signing and SBOM.
 - ✅ Verified tar format compliance (PAX matches Alpine)
 - ✅ Created comprehensive APK testing infrastructure
 - ✅ Integrated custom archives library for APK support
@@ -467,12 +487,74 @@ The following methods **cannot** be consolidated into BaseBuilder:
 These differences reflect **genuine format requirements**, not duplication.
 
 ### Known Limitations
-- **APK Trusted Installs**: No `.SIGN.RSA.*` stream yet — installable only via `apk add --allow-untrusted`
-- **APK Signing**: No signature support (development builds only)
+- **APK Trusted Installs**: Now supported via `pkg/signing/rsa.go` — packages can be signed with `--sign` for trusted installation
+- **RPM Changelog**: Currently a no-op due to rpmpack v0.7.1 API gap. Tracked for future implementation when rpmpack adds changelog support
 
 ### Development Priorities
-1. Add RSA signing support and emit the third concatenated gzip stream
-2. Expand test coverage for APK builder (current: ~70%, target: 85%)
+1. Wire RPM changelog when rpmpack adds the API
+2. Expand test coverage for new packages (pkg/signing target 85%, pkg/sbom target 85%)
+3. Add `yap keygen` CLI subcommand for generating signing keys
+4. Add public-key extraction CLI (`yap pubkey`)
+5. Repository signing (Release.gpg, repodata signing) — separate concern from package signing
+
+## Signing & SBOM Subsystems
+
+### Signing (`pkg/signing/`)
+
+YAP supports cryptographic signing of built artifacts. The signing subsystem is format-aware and pluggable.
+
+**Format → Algorithm matrix:**
+
+| Format | Algorithm | Output | Notes |
+| ------ | --------- | ------ | ----- |
+| APK | RSA PKCS#1 v1.5 SHA1 | `.SIGN.RSA.<keyname>.rsa.pub` prepended as third gzip stream | Enables `apk add` without `--allow-untrusted` |
+| DEB | OpenPGP (GPG) | `<package>.deb.asc` ASCII-armored detached | Verify with `gpg --verify package.deb.asc package.deb` |
+| RPM | OpenPGP (GPG) | `<package>.rpm.asc` + optional in-RPM via `rpmpack.SetPGPSigner` | In-RPM preferred when supported |
+| Pacman | OpenPGP (GPG) | `<package>.pkg.tar.zst.sig` binary detached | Matches `makepkg --sign` convention |
+
+**Key resolution priority (highest to lowest):**
+1. CLI flag: `--sign-key /path/to/key`
+2. Format-specific env: `YAP_DEB_KEY`, `YAP_APK_KEY`, `YAP_RPM_KEY`, `YAP_PACMAN_KEY`
+3. Global env: `YAP_SIGN_KEY`
+4. yap.json: `signing.keyPath`
+5. Default search: `~/.config/yap/keys/<format>.{rsa,gpg}` then `~/.config/yap/keys/default.{rsa,gpg}`
+
+Passphrase resolution mirrors key resolution with `_PASSPHRASE` suffix.
+
+**Implementation:**
+- `pkg/signing/signing.go` — Format/Algorithm enums, Config, Signer interface
+- `pkg/signing/resolve.go` — Priority-based config resolution
+- `pkg/signing/factory.go` — `NewSigner(format, cfg) Signer`
+- `pkg/signing/rsa.go` — APK RSA signer (RSASigner)
+- `pkg/signing/gpg.go` — DEB/RPM/Pacman GPG signer (GPGSigner)
+
+**Pure-Go**: Uses `github.com/ProtonMail/go-crypto/openpgp` and stdlib `crypto/rsa`. No external `gpg` binary required — container-friendly.
+
+### SBOM (`pkg/sbom/`)
+
+Software Bill of Materials generation, opt-in via `--sbom`.
+
+**Formats:**
+- **CycloneDX 1.5** (`<artifact>.cdx.json`) — components with hashes, licenses, external refs
+- **SPDX 2.3** (`<artifact>.spdx.json`) — packages with DESCRIBES + DEPENDS_ON relationships
+
+**Selection:** `--sbom-format cyclonedx`, `--sbom-format spdx`, or `--sbom-format both` (default).
+
+**Data source:** PKGBUILD fields (name, version, license, depends, makedepends, sources, sha256/sha512 sums).
+
+**Implementation:** Hand-rolled to specification, no external SBOM library — keeps dependency surface minimal.
+
+### Build pipeline integration (`pkg/project/project.go`)
+
+```
+PrepareFakeroot → BuildPackage (returns artifactPath)
+                       ↓
+                  signArtifact (if proj.Signing.Enabled)
+                       ↓
+                  generateSBOM (if mpc.SBOM)
+```
+
+The `Builder.BuildPackage` interface returns `(string, error)` so the pipeline can address the resulting artifact for post-build hooks.
 
 ## Agent-Specific Context
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ YAP eliminates the need to learn multiple packaging formats and build systems by
 - **Enhanced PKGBUILD Support**: Extended syntax with custom variables and arrays
 - **Cross-Distribution Variables**: Distribution-specific configurations in single file
 - **Cross-Compilation Support**: Build packages for different architectures than your build environment
+- **Package Signing**: APK RSA + DEB/RPM/Pacman GPG signing via pure-Go ProtonMail/go-crypto
+- **SBOM Generation**: CycloneDX 1.5 and SPDX 2.3 sidecars for supply-chain transparency
+- **Per-Format Compression**: Choose `zstd`/`gzip`/`xz` for DEB and RPM packages
+- **Pacman .INSTALL Scriptlets**: Full 6-hook support (pre_install, post_install, pre_upgrade, post_upgrade, pre_remove, post_remove)
+- **Changelog Support**: PKGBUILD `changelog` field renders to native format per distro
 
 ### 🎯 **Developer Experience**
 - **Simple Configuration**: JSON project files with minimal setup
@@ -455,6 +460,57 @@ requires_pre=('shadow-utils')
 maintainer="John Doe <john@example.com>"
 ```
 
+#### Changelog Field
+
+YAP supports a top-level `changelog` field pointing to a changelog file in the package directory:
+
+```bash
+pkgname=my-package
+pkgver=1.0.0
+pkgrel=1
+changelog=CHANGELOG.md
+```
+
+The file is processed per format:
+- **DEB**: Compressed and installed at `usr/share/doc/<pkgname>/changelog.Debian.gz` (Lintian-compliant)
+- **Pacman**: Stored as `.CHANGELOG` in the package archive
+- **APK**: No native convention — field is ignored
+- **RPM**: Currently deferred pending rpmpack changelog API support
+
+#### Pacman Install Scriptlets
+
+For Pacman packages, YAP supports the full 6-hook lifecycle:
+
+```bash
+pre_install() {
+    echo "Before install"
+}
+
+post_install() {
+    systemctl daemon-reload
+}
+
+pre_upgrade() {
+    systemctl stop myservice
+}
+
+post_upgrade() {
+    systemctl start myservice
+}
+
+pre_remove() {
+    systemctl disable myservice
+}
+
+post_remove() {
+    systemctl daemon-reload
+}
+```
+
+These are emitted to `<pkgname>.install` and referenced by `install=` in the generated PKGBUILD. The `.install` file is only created when at least one hook is defined.
+
+When `pre_upgrade` / `post_upgrade` are absent, they fall back to `pre_install` / `post_install` for backward compatibility.
+
 ### Supported Distributions
 
 YAP supports building packages for the following distributions:
@@ -528,6 +584,22 @@ yap build --ssh-password pass    # SSH password for private repos
 yap build --target-arch arm64    # Cross-compile for a specific architecture
 yap build --skip-toolchain-validation  # Skip Go toolchain validation
 
+# Signing
+yap build --sign                          # Enable artifact signing (key resolved from flags/env/config/default)
+yap build --sign-key /path/to/private.key # Specify private key path
+yap build --sign-passphrase pass          # Passphrase (use env vars in CI: YAP_SIGN_PASSPHRASE)
+yap build --sign-key-name mykey           # APK key name (.SIGN.RSA.<keyname>.rsa.pub)
+
+# SBOM (Software Bill of Materials)
+yap build --sbom                          # Generate SBOM sidecars next to artifacts
+yap build --sbom-format cyclonedx         # Only CycloneDX 1.5 (default: both)
+yap build --sbom-format spdx              # Only SPDX 2.3
+yap build --sbom-format both              # Both formats (default)
+
+# Compression overrides
+yap build --compression-deb gzip          # DEB compression: zstd|gzip|xz (default: zstd)
+yap build --compression-rpm xz            # RPM compression: zstd|gzip|xz (default: zstd)
+
 # Debugging
 yap build --debug-dir /path/to/debug    # Emit split debug info to a directory
 
@@ -586,6 +658,108 @@ yap graph --show-external --output complete-graph.svg .
 - **Arrows**: Show dependency direction (runtime vs make dependencies)
 - **Levels**: Indicate build order and dependency hierarchy
 - **Tooltips**: Display detailed package information on hover
+
+## 🔐 Package Signing
+
+YAP can cryptographically sign built artifacts so end users can verify package authenticity.
+
+### Format support
+
+| Format | Algorithm | Output |
+| ------ | --------- | ------ |
+| APK | RSA PKCS#1 v1.5 SHA1 | Embedded `.SIGN.RSA.<keyname>.rsa.pub` stream — enables `apk add` without `--allow-untrusted` |
+| DEB | OpenPGP (GPG) | `<package>.deb.asc` (ASCII-armored detached) |
+| RPM | OpenPGP (GPG) | `<package>.rpm.asc` (detached) + in-RPM signature via rpmpack |
+| Pacman | OpenPGP (GPG) | `<package>.pkg.tar.zst.sig` (binary detached) |
+
+### Quick start
+
+```bash
+# Generate an APK RSA key (Alpine standard)
+abuild-keygen -a -i
+
+# Sign an APK build
+yap build --sign --sign-key ~/.abuild/your-key.rsa --sign-key-name your-key alpine examples/yap
+
+# Sign a DEB build with GPG
+yap build --sign --sign-key ~/.gnupg/private.asc ubuntu examples/yap
+```
+
+### Key resolution priority
+
+1. `--sign-key <path>` CLI flag
+2. Format-specific env: `YAP_APK_KEY`, `YAP_DEB_KEY`, `YAP_RPM_KEY`, `YAP_PACMAN_KEY`
+3. Global env: `YAP_SIGN_KEY`
+4. `yap.json` field `signing.keyPath`
+5. Default search: `~/.config/yap/keys/<format>.{rsa,gpg}` then `~/.config/yap/keys/default.{rsa,gpg}`
+
+Passphrase resolution mirrors key resolution with `_PASSPHRASE` suffix (`YAP_DEB_PASSPHRASE`, etc.).
+
+### yap.json signing config
+
+```json
+{
+  "name": "my-project",
+  "signing": {
+    "enabled": true,
+    "keyPath": "~/.config/yap/keys/release.gpg",
+    "keyName": "release"
+  },
+  "projects": [...]
+}
+```
+
+### Verifying signed packages
+
+```bash
+# APK (after distributing the public key to /etc/apk/keys/)
+apk add my-package.apk
+
+# DEB
+gpg --verify my-package_1.0.0_amd64.deb.asc my-package_1.0.0_amd64.deb
+
+# RPM
+rpm -K my-package-1.0.0-1.x86_64.rpm
+
+# Pacman
+pacman-key --verify my-package-1.0.0-1-x86_64.pkg.tar.zst.sig
+```
+
+## 📦 SBOM Generation
+
+YAP can emit Software Bill of Materials (SBOM) sidecars next to built artifacts in CycloneDX 1.5 and SPDX 2.3 formats.
+
+### Quick start
+
+```bash
+# Generate both formats (default)
+yap build --sbom .
+
+# Only CycloneDX
+yap build --sbom --sbom-format cyclonedx .
+
+# Only SPDX
+yap build --sbom --sbom-format spdx .
+```
+
+### Output
+
+Each artifact gets sidecar files:
+```
+artifacts/
+├── ubuntu/
+│   ├── my-package_1.0.0-1_amd64.deb
+│   ├── my-package_1.0.0-1_amd64.deb.cdx.json    ← CycloneDX 1.5
+│   └── my-package_1.0.0-1_amd64.deb.spdx.json   ← SPDX 2.3
+```
+
+### Captured metadata
+
+- Package name, version, license
+- Runtime and build dependencies
+- Source URLs and checksums
+- File hashes
+- DESCRIBES / DEPENDS_ON relationships (SPDX)
 
 ## 🔧 Advanced Usage
 

--- a/cmd/yap/command/build.go
+++ b/cmd/yap/command/build.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/M0Rf30/yap/v2/pkg/builders/common"
+	"github.com/M0Rf30/yap/v2/pkg/core"
 	yapErrors "github.com/M0Rf30/yap/v2/pkg/errors"
 	"github.com/M0Rf30/yap/v2/pkg/i18n"
 	"github.com/M0Rf30/yap/v2/pkg/logger"
@@ -19,6 +20,24 @@ import (
 
 // sshPassword is the local holder for the --ssh-password flag value.
 var sshPassword string
+
+// compressionDeb is the local holder for the --compression-deb flag value.
+var compressionDeb string
+
+// compressionRpm is the local holder for the --compression-rpm flag value.
+var compressionRpm string
+
+// signKey is the local holder for the --sign-key flag value.
+var signKey string
+
+// signPassphrase is the local holder for the --sign-passphrase flag value.
+var signPassphrase string
+
+// signKeyName is the local holder for the --sign-key-name flag value.
+var signKeyName string
+
+// sign is the local holder for the --sign flag value.
+var sign bool
 
 // buildCmd represents the command to build the entire project.
 var buildCmd = &cobra.Command{
@@ -82,6 +101,40 @@ var buildCmd = &cobra.Command{
 			return err
 		}
 
+		// Apply CLI compression flags if provided
+		if compressionDeb != "" {
+			if err := validateCompression(compressionDeb); err != nil {
+				return err
+			}
+
+			mpc.CompressionDeb = compressionDeb
+		}
+
+		if compressionRpm != "" {
+			if err := validateCompression(compressionRpm); err != nil {
+				return err
+			}
+
+			mpc.CompressionRpm = compressionRpm
+		}
+
+		// Propagate compression settings to all projects
+		for _, proj := range mpc.Projects {
+			proj.CompressionDeb = mpc.CompressionDeb
+			proj.CompressionRpm = mpc.CompressionRpm
+		}
+
+		// Apply CLI signing flags if provided
+		if sign {
+			// Resolve signing configuration from CLI flags, env vars, and project config
+			signingCfg := resolveSigning(&mpc)
+
+			// Propagate signing config to all projects
+			for _, proj := range mpc.Projects {
+				proj.Signing = signingCfg
+			}
+		}
+
 		logger.Info(i18n.T("logger.build.project_init_success"))
 
 		// Build packages with timestamp logging
@@ -103,6 +156,54 @@ var buildCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+// validateCompression validates that the compression algorithm is supported.
+func validateCompression(compression string) error {
+	switch compression {
+	case "zstd", "gzip", "xz":
+		return nil
+	default:
+		return yapErrors.New(
+			yapErrors.ErrTypeConfiguration,
+			"unsupported compression algorithm",
+		).WithContext("compression", compression).
+			WithOperation("validateCompression")
+	}
+}
+
+// resolveSigning resolves the signing configuration from CLI flags,
+// environment variables, and project config.
+func resolveSigning(mpc *project.MultipleProject) *core.SigningConfig {
+	// Get config from project if available
+	configKey := ""
+	configPass := ""
+
+	if mpc.Signing != nil {
+		configKey = mpc.Signing.KeyPath
+		configPass = mpc.Signing.Passphrase
+	}
+
+	// For now, we'll use a simple signing config that just stores the values
+	// Phase 3/4 will integrate with the actual signing.Resolve() function
+	cfg := &core.SigningConfig{
+		Enabled:    sign,
+		KeyPath:    signKey,
+		Passphrase: signPassphrase,
+		KeyName:    signKeyName,
+	}
+
+	// If no CLI key provided, try config
+	if cfg.KeyPath == "" && configKey != "" {
+		cfg.KeyPath = configKey
+	}
+
+	// If no CLI passphrase provided, try config
+	if cfg.Passphrase == "" && configPass != "" {
+		cfg.Passphrase = configPass
+	}
+
+	return cfg
 }
 
 // logStructuredError logs a concise fatal build error.
@@ -163,6 +264,14 @@ func InitializeBuildDescriptions() {
 	buildCmd.Flag("to").Usage = i18n.T("flags.build.to")
 	buildCmd.Flag("only").Usage = i18n.T("flags.build.only")
 	buildCmd.Flag("target-arch").Usage = i18n.T("flags.build.target_arch")
+	buildCmd.Flag("sbom").Usage = i18n.T("flags.build.sbom")
+	buildCmd.Flag("sbom-format").Usage = i18n.T("flags.build.sbom_format")
+	buildCmd.Flag("compression-deb").Usage = i18n.T("flags.build.compression_deb")
+	buildCmd.Flag("compression-rpm").Usage = i18n.T("flags.build.compression_rpm")
+	buildCmd.Flag("sign").Usage = i18n.T("flags.build.sign")
+	buildCmd.Flag("sign-key").Usage = i18n.T("flags.build.sign_key")
+	buildCmd.Flag("sign-passphrase").Usage = i18n.T("flags.build.sign_passphrase")
+	buildCmd.Flag("sign-key-name").Usage = i18n.T("flags.build.sign_key_name")
 }
 
 //nolint:gochecknoinits // Required for cobra command registration
@@ -237,4 +346,26 @@ func init() {
 	// DEBUG SYMBOL FLAGS
 	buildCmd.Flags().StringVarP(&project.DebugDir,
 		"debug-dir", "", "", "Output directory for separated debug symbols (.build-id structure for debuginfod)")
+
+	// SBOM GENERATION FLAGS
+	buildCmd.Flags().BoolVarP(&project.SBOM,
+		"sbom", "", false, "")
+	buildCmd.Flags().StringVarP(&project.SBOMFormat,
+		"sbom-format", "", "both", "")
+
+	// COMPRESSION FLAGS
+	buildCmd.Flags().StringVarP(&compressionDeb,
+		"compression-deb", "", "zstd", "Compression algorithm for DEB packages (zstd, gzip, xz)")
+	buildCmd.Flags().StringVarP(&compressionRpm,
+		"compression-rpm", "", "zstd", "Compression algorithm for RPM packages (zstd, gzip, xz)")
+
+	// SIGNING FLAGS
+	buildCmd.Flags().BoolVarP(&sign,
+		"sign", "", false, "Enable package signing")
+	buildCmd.Flags().StringVarP(&signKey,
+		"sign-key", "", "", "Path to private key for signing (PEM for RSA, ASCII-armored for GPG)")
+	buildCmd.Flags().StringVarP(&signPassphrase,
+		"sign-passphrase", "", "", "Passphrase for private key (prefer env var YAP_SIGN_PASSPHRASE)")
+	buildCmd.Flags().StringVarP(&signKeyName,
+		"sign-key-name", "", "", "Key name for APK signing (e.g., 'mykey')")
 }

--- a/cmd/yap/command/build_test.go
+++ b/cmd/yap/command/build_test.go
@@ -62,3 +62,52 @@ func TestBuildCommandDefinition(t *testing.T) {
 		t.Error("Build command should have a RunE function")
 	}
 }
+
+func TestValidateCompression(t *testing.T) {
+	tests := []struct {
+		name        string
+		compression string
+		shouldError bool
+	}{
+		{
+			name:        "valid zstd",
+			compression: "zstd",
+			shouldError: false,
+		},
+		{
+			name:        "valid gzip",
+			compression: "gzip",
+			shouldError: false,
+		},
+		{
+			name:        "valid xz",
+			compression: "xz",
+			shouldError: false,
+		},
+		{
+			name:        "invalid compression",
+			compression: "invalid",
+			shouldError: true,
+		},
+		{
+			name:        "empty compression",
+			compression: "",
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCompression(tt.compression)
+			if (err != nil) != tt.shouldError {
+				t.Errorf("validateCompression(%q) error = %v, shouldError = %v",
+					tt.compression, err, tt.shouldError)
+			}
+
+			if tt.shouldError && err == nil {
+				t.Errorf("validateCompression(%q) should have returned an error",
+					tt.compression)
+			}
+		})
+	}
+}

--- a/cmd/yap/command/prepare.go
+++ b/cmd/yap/command/prepare.go
@@ -43,7 +43,7 @@ var (
 			distro, _ = ResolveDistroRelease(distro, release,
 				"logger.prepare.no_distribution_specified")
 
-			packageManager := packer.GetPackageManager(&pkgbuild.PKGBUILD{}, distro)
+			packageManager := packer.GetPackageManager(&pkgbuild.PKGBUILD{}, distro, "", "")
 			if !project.SkipSyncDeps {
 				err := packageManager.Update()
 				if err != nil {

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -10,20 +10,50 @@ import (
 
 	"github.com/mholt/archives"
 
+	"github.com/M0Rf30/yap/v2/pkg/errors"
 	"github.com/M0Rf30/yap/v2/pkg/i18n"
 	"github.com/M0Rf30/yap/v2/pkg/logger"
 )
 
-// CreateTarZst creates a compressed tar.zst archive from the specified source
-// directory. This consolidates the archive creation logic for YAP packages.
-func CreateTarZst(ctx context.Context, sourceDir, outputFile string, formatGNU bool) error {
+// CreateTarCompressed creates a compressed tar archive with the specified
+// compression algorithm from the source directory. Supported compression
+// algorithms are "zstd", "gzip", and "xz". If compression is empty, defaults
+// to "zstd". Returns an error if the compression algorithm is unsupported.
+func CreateTarCompressed(
+	ctx context.Context,
+	sourceDir,
+	outputFile,
+	compression string,
+	formatGNU bool,
+) error {
+	// Default to zstd if not specified
+	if compression == "" {
+		compression = "zstd"
+	}
+
+	// Map compression string to archives.Compression
+	var compressor archives.Compression
+
+	switch compression {
+	case "zstd":
+		compressor = archives.Zstd{}
+	case "gzip":
+		compressor = archives.Gz{}
+	case "xz":
+		compressor = archives.Xz{}
+	default:
+		return errors.New(
+			errors.ErrTypeConfiguration,
+			"unsupported compression algorithm",
+		).WithContext("compression", compression).
+			WithOperation("CreateTarCompressed")
+	}
+
 	options := &archives.FromDiskOptions{
 		FollowSymlinks: false,
 	}
 
 	// Retrieve the list of files from the source directory on disk.
-	// The map specifies that the files should be read from the sourceDir
-	// and the output path in the archive should be empty.
 	files, err := archives.FilesFromDisk(ctx, options, map[string]string{
 		sourceDir + string(os.PathSeparator): "",
 	})
@@ -54,7 +84,7 @@ func CreateTarZst(ctx context.Context, sourceDir, outputFile string, formatGNU b
 	}()
 
 	format := archives.CompressedArchive{
-		Compression: archives.Zstd{},
+		Compression: compressor,
 		Archival: archives.Tar{
 			FormatGNU: formatGNU,
 			Uid:       0,
@@ -65,6 +95,13 @@ func CreateTarZst(ctx context.Context, sourceDir, outputFile string, formatGNU b
 	}
 
 	return format.Archive(ctx, out, files)
+}
+
+// CreateTarZst creates a compressed tar.zst archive from the specified source
+// directory. This is a convenience wrapper around CreateTarCompressed that
+// defaults to zstd compression.
+func CreateTarZst(ctx context.Context, sourceDir, outputFile string, formatGNU bool) error {
+	return CreateTarCompressed(ctx, sourceDir, outputFile, "zstd", formatGNU)
 }
 
 // Extract extracts an archive file to the specified destination directory.

--- a/pkg/archive/tar_test.go
+++ b/pkg/archive/tar_test.go
@@ -154,3 +154,193 @@ func TestExtractInvalidArchive(t *testing.T) {
 		t.Fatal("Expected error for invalid archive file, got nil")
 	}
 }
+
+func TestCreateTarCompressedWithGzip(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	sourceDir := filepath.Join(tempDir, "source")
+	outputFile := filepath.Join(tempDir, "test.tar.gz")
+
+	// Create source directory with a test file
+	err := os.MkdirAll(sourceDir, 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create source directory: %v", err)
+	}
+
+	testFile := filepath.Join(sourceDir, "test.txt")
+
+	err = os.WriteFile(testFile, []byte("test content"), 0o644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Test creating tar.gz archive
+	err = archive.CreateTarCompressed(context.Background(), sourceDir, outputFile,
+		"gzip", false)
+	if err != nil {
+		t.Fatalf("CreateTarCompressed with gzip failed: %v", err)
+	}
+
+	// Verify the output file exists
+	if _, err := os.Stat(outputFile); os.IsNotExist(err) {
+		t.Fatalf("Output file was not created")
+	}
+
+	// Verify gzip magic bytes (1f 8b)
+	file, err := os.Open(outputFile)
+	if err != nil {
+		t.Fatalf("Failed to open output file: %v", err)
+	}
+
+	defer func() { _ = file.Close() }()
+
+	magic := make([]byte, 2)
+
+	_, err = file.Read(magic)
+	if err != nil {
+		t.Fatalf("Failed to read magic bytes: %v", err)
+	}
+
+	if magic[0] != 0x1f || magic[1] != 0x8b {
+		t.Fatalf("Invalid gzip magic bytes: got %x %x, expected 1f 8b",
+			magic[0], magic[1])
+	}
+}
+
+func TestCreateTarCompressedWithXz(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	sourceDir := filepath.Join(tempDir, "source")
+	outputFile := filepath.Join(tempDir, "test.tar.xz")
+
+	// Create source directory with a test file
+	err := os.MkdirAll(sourceDir, 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create source directory: %v", err)
+	}
+
+	testFile := filepath.Join(sourceDir, "test.txt")
+
+	err = os.WriteFile(testFile, []byte("test content"), 0o644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Test creating tar.xz archive
+	err = archive.CreateTarCompressed(context.Background(), sourceDir, outputFile,
+		"xz", false)
+	if err != nil {
+		t.Fatalf("CreateTarCompressed with xz failed: %v", err)
+	}
+
+	// Verify the output file exists
+	if _, err := os.Stat(outputFile); os.IsNotExist(err) {
+		t.Fatalf("Output file was not created")
+	}
+
+	// Verify xz magic bytes (fd 37 7a 58 5a 00)
+	file, err := os.Open(outputFile)
+	if err != nil {
+		t.Fatalf("Failed to open output file: %v", err)
+	}
+
+	defer func() { _ = file.Close() }()
+
+	magic := make([]byte, 6)
+
+	_, err = file.Read(magic)
+	if err != nil {
+		t.Fatalf("Failed to read magic bytes: %v", err)
+	}
+
+	expectedMagic := []byte{0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00}
+
+	for i, b := range magic {
+		if b != expectedMagic[i] {
+			t.Fatalf("Invalid xz magic bytes at position %d: got %x, expected %x",
+				i, b, expectedMagic[i])
+		}
+	}
+}
+
+func TestCreateTarCompressedWithZstd(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	sourceDir := filepath.Join(tempDir, "source")
+	outputFile := filepath.Join(tempDir, "test.tar.zst")
+
+	// Create source directory with a test file
+	err := os.MkdirAll(sourceDir, 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create source directory: %v", err)
+	}
+
+	testFile := filepath.Join(sourceDir, "test.txt")
+
+	err = os.WriteFile(testFile, []byte("test content"), 0o644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Test creating tar.zst archive
+	err = archive.CreateTarCompressed(context.Background(), sourceDir, outputFile,
+		"zstd", false)
+	if err != nil {
+		t.Fatalf("CreateTarCompressed with zstd failed: %v", err)
+	}
+
+	// Verify the output file exists
+	if _, err := os.Stat(outputFile); os.IsNotExist(err) {
+		t.Fatalf("Output file was not created")
+	}
+}
+
+func TestCreateTarCompressedInvalidCompression(t *testing.T) {
+	tempDir := t.TempDir()
+	sourceDir := filepath.Join(tempDir, "source")
+	outputFile := filepath.Join(tempDir, "test.tar")
+
+	err := os.MkdirAll(sourceDir, 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create source directory: %v", err)
+	}
+
+	// Test with invalid compression algorithm
+	err = archive.CreateTarCompressed(context.Background(), sourceDir, outputFile,
+		"invalid", false)
+	if err == nil {
+		t.Fatal("Expected error for invalid compression algorithm, got nil")
+	}
+}
+
+func TestCreateTarCompressedDefaultCompression(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	sourceDir := filepath.Join(tempDir, "source")
+	outputFile := filepath.Join(tempDir, "test.tar.zst")
+
+	// Create source directory with a test file
+	err := os.MkdirAll(sourceDir, 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create source directory: %v", err)
+	}
+
+	testFile := filepath.Join(sourceDir, "test.txt")
+
+	err = os.WriteFile(testFile, []byte("test content"), 0o644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Test creating tar archive with empty compression (should default to zstd)
+	err = archive.CreateTarCompressed(context.Background(), sourceDir, outputFile,
+		"", false)
+	if err != nil {
+		t.Fatalf("CreateTarCompressed with empty compression failed: %v", err)
+	}
+
+	// Verify the output file exists
+	if _, err := os.Stat(outputFile); os.IsNotExist(err) {
+		t.Fatalf("Output file was not created")
+	}
+}

--- a/pkg/builders/apk/apk.go
+++ b/pkg/builders/apk/apk.go
@@ -44,7 +44,8 @@ func NewBuilder(pkgBuild *pkgbuild.PKGBUILD) *Apk {
 // BuildPackage creates an APK package in pure Go without external dependencies.
 // The package is created as a gzip-compressed tar archive containing the package
 // files and metadata (.PKGINFO and optional .install script).
-func (a *Apk) BuildPackage(artifactsPath string, targetArch string) error {
+// Returns the path to the created APK file.
+func (a *Apk) BuildPackage(artifactsPath string, targetArch string) (string, error) {
 	a.SetTargetArchitecture(targetArch)
 
 	pkgName := a.BuildPackageName(".apk")
@@ -52,12 +53,12 @@ func (a *Apk) BuildPackage(artifactsPath string, targetArch string) error {
 
 	err := a.createAPKPackage(pkgFilePath, artifactsPath)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	a.LogPackageCreated(pkgFilePath)
 
-	return nil
+	return pkgFilePath, nil
 }
 
 // PrepareFakeroot sets up the APK package metadata.
@@ -96,6 +97,9 @@ func (a *Apk) PrepareFakeroot(artifactsPath string, targetArch string) error {
 			return err
 		}
 	}
+
+	// Note: APK format does not have a native changelog convention.
+	// Changelog support is skipped for APK packages.
 
 	return nil
 }

--- a/pkg/builders/apk/apk_test.go
+++ b/pkg/builders/apk/apk_test.go
@@ -63,7 +63,7 @@ func TestBuildPackage(t *testing.T) {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
 
-	err = builder.BuildPackage(tempDir, "")
+	_, err = builder.BuildPackage(tempDir, "")
 	if err != nil {
 		t.Errorf("BuildPackage failed: %v", err)
 	}

--- a/pkg/builders/common/interface.go
+++ b/pkg/builders/common/interface.go
@@ -58,7 +58,7 @@ var depVersionRegex = regexp.MustCompile(`(<=|>=|=|>|<)`)
 // This unifies the behavior across different package formats (APK, DEB, RPM, Pacman).
 type Builder interface {
 	// BuildPackage creates the package file at the specified artifacts path
-	BuildPackage(artifactsPath string, targetArch string) error
+	BuildPackage(artifactsPath string, targetArch string) (string, error)
 
 	// PrepareFakeroot sets up the package metadata and prepares the build environment
 	PrepareFakeroot(artifactsPath string, targetArch string) error

--- a/pkg/builders/deb/dpkg.go
+++ b/pkg/builders/deb/dpkg.go
@@ -2,6 +2,7 @@
 package deb
 
 import (
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -28,27 +29,34 @@ import (
 // contains the metadata and build instructions for the package.
 type Package struct {
 	*common.BaseBuilder
-	debDir string
+	debDir      string
+	compression string
 }
 
-// NewBuilder creates a new Debian package manager.
-func NewBuilder(pkgBuild *pkgbuild.PKGBUILD) *Package {
+// NewBuilder creates a new Debian package manager with optional compression setting.
+// If compression is empty, defaults to "zstd".
+func NewBuilder(pkgBuild *pkgbuild.PKGBUILD, compression string) *Package {
+	if compression == "" {
+		compression = "zstd"
+	}
+
 	return &Package{
 		BaseBuilder: common.NewBaseBuilder(pkgBuild, "deb"),
 		debDir:      "",
+		compression: compression,
 	}
 }
 
 // BuildPackage builds the Debian package and cleans up afterward.
 // It takes artifactsPath to specify where to store the package.
 // The method calls dpkgDeb to create the package and removes the
-// package directory, returning an error if any step fails.
-func (d *Package) BuildPackage(artifactsPath string, targetArch string) error {
+// package directory, returning the path to the created DEB file and an error if any step fails.
+func (d *Package) BuildPackage(artifactsPath string, targetArch string) (string, error) {
 	d.LogCrossCompilation(targetArch)
 
 	debTemp, err := os.MkdirTemp(d.PKGBUILD.SourceDir, "tmp")
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	defer func() {
@@ -63,33 +71,35 @@ func (d *Package) BuildPackage(artifactsPath string, targetArch string) error {
 	dataArchive := filepath.Join(debTemp, dataFilename)
 
 	// Create control archive
-	err = archive.CreateTarZst(context.Background(), d.debDir, controlArchive, true)
+	err = archive.CreateTarCompressed(context.Background(), d.debDir, controlArchive,
+		d.compression, true)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	err = os.RemoveAll(d.debDir)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Create data archive
-	err = archive.CreateTarZst(context.Background(), d.PKGBUILD.PackageDir, dataArchive, true)
+	err = archive.CreateTarCompressed(context.Background(), d.PKGBUILD.PackageDir,
+		dataArchive, d.compression, true)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	err = d.createDeb(artifactsPath, controlArchive, dataArchive)
+	debPath, err := d.createDeb(artifactsPath, controlArchive, dataArchive)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	err = os.RemoveAll(d.PKGBUILD.PackageDir)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return debPath, nil
 }
 
 // PrepareFakeroot sets up the environment for building a Debian package in a fakeroot context.
@@ -293,11 +303,68 @@ func (d *Package) createDebconfFile(name, variable string) error {
 	return copy.Copy(assetPath, destPath)
 }
 
+// createChangelogFile creates the changelog file for the Debian package.
+// It reads the changelog from PKGBUILD, gzip-compresses it, and writes it to
+// usr/share/doc/<pkgname>/changelog.Debian.gz in the package directory.
+// Returns nil if no changelog is specified.
+func (d *Package) createChangelogFile() error {
+	changelogData, err := d.PKGBUILD.ReadChangelog()
+	if err != nil {
+		return err
+	}
+
+	if changelogData == nil {
+		return nil
+	}
+
+	// Create the doc directory structure
+	docDir := filepath.Join(d.PKGBUILD.PackageDir, "usr", "share", "doc",
+		d.PKGBUILD.PkgName)
+
+	err = files.ExistsMakeDir(docDir)
+	if err != nil {
+		return err
+	}
+
+	// Create and write the gzip-compressed changelog
+	changelogPath := filepath.Join(docDir, "changelog.Debian.gz")
+
+	changelogFile, err := os.Create(filepath.Clean(changelogPath))
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if cerr := changelogFile.Close(); cerr != nil {
+			logger.Warn("failed to close changelog file", "path", changelogPath,
+				"error", cerr)
+		}
+	}()
+
+	gzWriter := gzip.NewWriter(changelogFile)
+	defer func() {
+		if cerr := gzWriter.Close(); cerr != nil {
+			logger.Warn("failed to close gzip writer", "path", changelogPath,
+				"error", cerr)
+		}
+	}()
+
+	// Set the modification time for reproducibility
+	gzWriter.ModTime = files.SourceDateEpochFromEnv()
+
+	_, err = gzWriter.Write(changelogData)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // createDeb generates Deb package files from the given artifact path.
 // It takes a string parameter `artifactPath` which represents the path
 // where the Deb package files will be generated. The function returns
-// an error if there was an issue generating the Deb package files.
-func (d *Package) createDeb(artifactPath, control, data string) error {
+// the path to the created DEB file and an error if there was an issue generating the Deb package files.
+func (d *Package) createDeb(artifactPath, control, data string) (string, error) {
 	// Create the .deb package
 	artifactFilePath := filepath.Join(artifactPath,
 		fmt.Sprintf("%s_%s-%s_%s.deb",
@@ -309,7 +376,7 @@ func (d *Package) createDeb(artifactPath, control, data string) error {
 
 	debPackage, err := os.Create(cleanFilePath)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	defer func() {
@@ -323,7 +390,7 @@ func (d *Package) createDeb(artifactPath, control, data string) error {
 
 	err = writer.WriteGlobalHeader()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	modtime := files.SourceDateEpochFromEnv()
@@ -333,23 +400,23 @@ func (d *Package) createDeb(artifactPath, control, data string) error {
 		debianBinary,
 		modtime)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	err = addArFileFromPath(writer, controlFilename, control, modtime)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	err = addArFileFromPath(writer, dataFilename, data, modtime)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Log package creation using common functionality
 	d.LogPackageCreated(artifactFilePath)
 
-	return nil
+	return cleanFilePath, nil
 }
 
 // createDebResources creates the Deb package resources.
@@ -410,6 +477,11 @@ func (d *Package) createDebResources() error {
 
 	err = d.createDebconfFile("templates",
 		d.PKGBUILD.DebTemplate)
+	if err != nil {
+		return err
+	}
+
+	err = d.createChangelogFile()
 	if err != nil {
 		return err
 	}

--- a/pkg/builders/deb/dpkg_test.go
+++ b/pkg/builders/deb/dpkg_test.go
@@ -38,7 +38,7 @@ func createTestPKGBUILD() *pkgbuild.PKGBUILD {
 
 func TestNewBuilder(t *testing.T) {
 	pkgBuild := createTestPKGBUILD()
-	pkg := NewBuilder(pkgBuild)
+	pkg := NewBuilder(pkgBuild, "")
 
 	if pkg == nil {
 		t.Fatal("NewBuilder returned nil")
@@ -51,7 +51,7 @@ func TestNewBuilder(t *testing.T) {
 
 func TestBuildPackage(t *testing.T) {
 	pkgBuild := createTestPKGBUILD()
-	pkg := NewBuilder(pkgBuild)
+	pkg := NewBuilder(pkgBuild, "")
 
 	tempDir, err := os.MkdirTemp("", "deb-test")
 	if err != nil {
@@ -94,7 +94,7 @@ func TestBuildPackage(t *testing.T) {
 		t.Fatalf("Failed to create artifacts dir: %v", err)
 	}
 
-	err = pkg.BuildPackage(artifactsDir, "")
+	_, err = pkg.BuildPackage(artifactsDir, "")
 	if err != nil {
 		t.Errorf("BuildPackage failed: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestPrepare(t *testing.T) {
 	}
 
 	pkgBuild := createTestPKGBUILD()
-	pkg := NewBuilder(pkgBuild)
+	pkg := NewBuilder(pkgBuild, "")
 
 	makeDepends := []string{"make", "gcc"}
 	err := pkg.Prepare(makeDepends, "")
@@ -124,7 +124,7 @@ func TestPrepareEnvironment(t *testing.T) {
 	}
 
 	pkgBuild := createTestPKGBUILD()
-	pkg := NewBuilder(pkgBuild)
+	pkg := NewBuilder(pkgBuild, "")
 
 	err := pkg.PrepareEnvironment(false, "")
 	// This will likely fail since apt-get isn't available, but we test the method call
@@ -140,7 +140,7 @@ func TestPrepareEnvironmentWithGolang(t *testing.T) {
 	}
 
 	pkgBuild := createTestPKGBUILD()
-	pkg := NewBuilder(pkgBuild)
+	pkg := NewBuilder(pkgBuild, "")
 
 	err := pkg.PrepareEnvironment(true, "")
 	// This will likely fail since apt-get isn't available, but we test the method call
@@ -151,7 +151,7 @@ func TestPrepareEnvironmentWithGolang(t *testing.T) {
 
 func TestPrepareFakeroot(t *testing.T) {
 	pkgBuild := createTestPKGBUILD()
-	pkg := NewBuilder(pkgBuild)
+	pkg := NewBuilder(pkgBuild, "")
 
 	tempDir, err := os.MkdirTemp("", "deb-test")
 	if err != nil {
@@ -194,7 +194,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	pkgBuild := createTestPKGBUILD()
-	pkg := NewBuilder(pkgBuild)
+	pkg := NewBuilder(pkgBuild, "")
 
 	err := pkg.Update()
 	// This will likely fail since apt-get isn't available, but we test the method call
@@ -205,7 +205,7 @@ func TestUpdate(t *testing.T) {
 
 func TestGetRelease(t *testing.T) {
 	pkgBuild := createTestPKGBUILD()
-	pkg := NewBuilder(pkgBuild)
+	pkg := NewBuilder(pkgBuild, "")
 
 	originalRel := pkg.PKGBUILD.PkgRel
 	pkg.getRelease()
@@ -223,7 +223,7 @@ func TestGetRelease(t *testing.T) {
 func TestGetReleaseWithDistro(t *testing.T) {
 	pkgBuild := createTestPKGBUILD()
 	pkgBuild.Codename = "" // Remove codename to test distro fallback
-	pkg := NewBuilder(pkgBuild)
+	pkg := NewBuilder(pkgBuild, "")
 
 	originalRel := pkg.PKGBUILD.PkgRel
 	pkg.getRelease()
@@ -239,7 +239,7 @@ func TestGetReleaseWithDistro(t *testing.T) {
 
 func TestProcessDepends(t *testing.T) {
 	pkgBuild := createTestPKGBUILD()
-	pkg := NewBuilder(pkgBuild)
+	pkg := NewBuilder(pkgBuild, "")
 
 	testCases := []struct {
 		input    []string
@@ -276,7 +276,7 @@ func TestProcessDepends(t *testing.T) {
 
 func TestCreateDebResources(t *testing.T) {
 	pkgBuild := createTestPKGBUILD()
-	pkg := NewBuilder(pkgBuild)
+	pkg := NewBuilder(pkgBuild, "")
 
 	tempDir, err := os.MkdirTemp("", "deb-test")
 	if err != nil {
@@ -320,7 +320,7 @@ func TestCreateDebResources(t *testing.T) {
 
 func TestCreateConfFiles(t *testing.T) {
 	pkgBuild := createTestPKGBUILD()
-	pkg := NewBuilder(pkgBuild)
+	pkg := NewBuilder(pkgBuild, "")
 
 	tempDir, err := os.MkdirTemp("", "deb-test")
 	if err != nil {
@@ -361,7 +361,7 @@ func TestCreateConfFiles(t *testing.T) {
 func TestCreateConfFilesEmpty(t *testing.T) {
 	pkgBuild := createTestPKGBUILD()
 	pkgBuild.Backup = []string{} // No backup files
-	pkg := NewBuilder(pkgBuild)
+	pkg := NewBuilder(pkgBuild, "")
 
 	tempDir, err := os.MkdirTemp("", "deb-test")
 	if err != nil {
@@ -386,7 +386,7 @@ func TestCreateConfFilesEmpty(t *testing.T) {
 
 func TestAddScriptlets(t *testing.T) {
 	pkgBuild := createTestPKGBUILD()
-	pkg := NewBuilder(pkgBuild)
+	pkg := NewBuilder(pkgBuild, "")
 
 	tempDir, err := os.MkdirTemp("", "deb-test")
 	if err != nil {
@@ -409,5 +409,87 @@ func TestAddScriptlets(t *testing.T) {
 		if _, err := os.Stat(scriptPath); os.IsNotExist(err) {
 			t.Errorf("Script %s was not created", script)
 		}
+	}
+}
+
+func TestCreateChangelogFile(t *testing.T) {
+	pkgBuild := createTestPKGBUILD()
+
+	tempDir, err := os.MkdirTemp("", "deb-changelog-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	// Create a changelog file
+	changelogPath := filepath.Join(tempDir, "CHANGELOG.md")
+	changelogContent := "# Changelog\n\n## Version 1.0\n- Initial release\n"
+
+	err = os.WriteFile(changelogPath, []byte(changelogContent), 0o644)
+	if err != nil {
+		t.Fatalf("Failed to create changelog file: %v", err)
+	}
+
+	// Create package directory
+	packageDir := filepath.Join(tempDir, "package")
+
+	err = os.MkdirAll(packageDir, 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create package dir: %v", err)
+	}
+
+	pkgBuild.StartDir = tempDir
+	pkgBuild.Changelog = "CHANGELOG.md"
+	pkgBuild.PackageDir = packageDir
+
+	pkg := NewBuilder(pkgBuild, "")
+
+	err = pkg.createChangelogFile()
+	if err != nil {
+		t.Errorf("createChangelogFile failed: %v", err)
+	}
+
+	// Check that the changelog file was created
+	expectedPath := filepath.Join(packageDir, "usr", "share", "doc",
+		pkgBuild.PkgName, "changelog.Debian.gz")
+	if _, err := os.Stat(expectedPath); os.IsNotExist(err) {
+		t.Errorf("Changelog file was not created at %s", expectedPath)
+	}
+}
+
+func TestCreateChangelogFile_NoChangelog(t *testing.T) {
+	pkgBuild := createTestPKGBUILD()
+
+	tempDir, err := os.MkdirTemp("", "deb-no-changelog-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	// Create package directory
+	packageDir := filepath.Join(tempDir, "package")
+
+	err = os.MkdirAll(packageDir, 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create package dir: %v", err)
+	}
+
+	pkgBuild.StartDir = tempDir
+	pkgBuild.Changelog = ""
+	pkgBuild.PackageDir = packageDir
+
+	pkg := NewBuilder(pkgBuild, "")
+
+	err = pkg.createChangelogFile()
+	if err != nil {
+		t.Errorf("createChangelogFile failed: %v", err)
+	}
+
+	// Check that no changelog directory was created
+	docDir := filepath.Join(packageDir, "usr", "share", "doc")
+	if _, err := os.Stat(docDir); err == nil {
+		t.Errorf("Doc directory should not be created when changelog is empty")
 	}
 }

--- a/pkg/builders/pacman/constants.go
+++ b/pkg/builders/pacman/constants.go
@@ -111,13 +111,21 @@ post_install() {
 }
 {{- end }}
 
-{{- if .PreInst}}
+{{- if .PreUpgrade}}
+pre_upgrade() {
+{{.PreUpgrade}}
+}
+{{- else if .PreInst}}
 pre_upgrade() {
 {{.PreInst}}
 }
 {{- end }}
 
-{{- if .PostInst}}
+{{- if .PostUpgrade}}
+post_upgrade() {
+{{.PostUpgrade}}
+}
+{{- else if .PostInst}}
 post_upgrade() {
 {{.PostInst}}
 }
@@ -197,7 +205,9 @@ options=(
   {{ end }}
 )
 {{- end }}
+{{- if or .PreInst .PostInst .PreRm .PostRm .PreUpgrade .PostUpgrade}}
 install={{.PkgName}}.install
+{{- end }}
 
 package() {
 {{.Package}}

--- a/pkg/builders/pacman/makepkg.go
+++ b/pkg/builders/pacman/makepkg.go
@@ -46,8 +46,8 @@ func NewBuilder(pkgBuild *pkgbuild.PKGBUILD) *Pkg {
 // - artifactsPath: a string representing the path where the build artifacts will be stored.
 //
 // The method calls the internal pacmanBuild function to perform the actual build process.
-// It returns an error if the build process encounters any issues.
-func (m *Pkg) BuildPackage(artifactsPath string, targetArch string) error {
+// Returns the path to the created package file.
+func (m *Pkg) BuildPackage(artifactsPath string, targetArch string) (string, error) {
 	m.SetTargetArchitecture(targetArch)
 
 	completeVersion := m.PKGBUILD.PkgVer
@@ -66,13 +66,13 @@ func (m *Pkg) BuildPackage(artifactsPath string, targetArch string) error {
 
 	err := archive.CreateTarZst(context.Background(), m.PKGBUILD.PackageDir, pkgFilePath, false)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Log package creation using common functionality
 	m.LogPackageCreated(pkgFilePath)
 
-	return nil
+	return pkgFilePath, nil
 }
 
 // PrepareFakeroot sets um the environment for building a package in a fakeroot context.
@@ -86,6 +86,38 @@ func (m *Pkg) PrepareFakeroot(artifactsPath string, targetArch string) error {
 	// Note: Don't override ArchComputed here - it should remain the native architecture
 	// The targetArch is used for package naming in BuildPackage method
 
+	if err := m.computeBuildMetadata(artifactsPath); err != nil {
+		return err
+	}
+
+	if err := m.renderPKGBUILDFile(); err != nil {
+		return err
+	}
+
+	if err := m.writePackageMetadata(); err != nil {
+		return err
+	}
+
+	if m.PKGBUILD.StripEnabled {
+		if err := options.Strip(m.PKGBUILD.PackageDir); err != nil {
+			return err
+		}
+	}
+
+	if err := m.writeMTREE(); err != nil {
+		return err
+	}
+
+	if err := m.writeInstallScriptIfNeeded(); err != nil {
+		return err
+	}
+
+	return m.writeChangelogIfPresent()
+}
+
+// computeBuildMetadata computes installed size, source date epoch, and other
+// PKGBUILD metadata fields needed for spec rendering.
+func (m *Pkg) computeBuildMetadata(artifactsPath string) error {
 	installedSize, err := files.GetDirSize(m.PKGBUILD.PackageDir)
 	if err != nil {
 		return fmt.Errorf("failed to get package dir size: %w", err)
@@ -105,14 +137,17 @@ func (m *Pkg) PrepareFakeroot(artifactsPath string, targetArch string) error {
 	m.PKGBUILD.PkgType = pkgTypeDefault // can be pkg, split, debug, src
 	m.PKGBUILD.YAPVersion = constants.YAPVersion
 
-	tmpl := m.PKGBUILD.RenderSpec(specFile)
+	return nil
+}
 
-	// Define the path to the PKGBUILD file
+// renderPKGBUILDFile renders and writes the PKGBUILD spec, then computes its
+// SHA256 checksum for inclusion in .BUILDINFO.
+func (m *Pkg) renderPKGBUILDFile() error {
+	tmpl := m.PKGBUILD.RenderSpec(specFile)
 	pkgBuildFile := filepath.Join(m.pacmanDir, "PKGBUILD")
 
 	if m.PKGBUILD.Home != m.PKGBUILD.StartDir {
-		err := m.PKGBUILD.CreateSpec(pkgBuildFile, tmpl)
-		if err != nil {
+		if err := m.PKGBUILD.CreateSpec(pkgBuildFile, tmpl); err != nil {
 			return err
 		}
 	}
@@ -124,63 +159,71 @@ func (m *Pkg) PrepareFakeroot(artifactsPath string, targetArch string) error {
 
 	m.PKGBUILD.Checksum = hex.EncodeToString(checksumBytes)
 
-	tmpl = m.PKGBUILD.RenderSpec(dotPkginfo)
+	return nil
+}
 
-	err = m.PKGBUILD.CreateSpec(filepath.Join(m.PKGBUILD.PackageDir,
-		".PKGINFO"), tmpl)
-	if err != nil {
+// writePackageMetadata renders and writes the .PKGINFO and .BUILDINFO files.
+func (m *Pkg) writePackageMetadata() error {
+	pkgInfoTmpl := m.PKGBUILD.RenderSpec(dotPkginfo)
+	if err := m.PKGBUILD.CreateSpec(
+		filepath.Join(m.PKGBUILD.PackageDir, ".PKGINFO"), pkgInfoTmpl); err != nil {
 		return err
 	}
 
-	tmpl = m.PKGBUILD.RenderSpec(dotBuildinfo)
+	buildInfoTmpl := m.PKGBUILD.RenderSpec(dotBuildinfo)
 
-	err = m.PKGBUILD.CreateSpec(filepath.Join(m.PKGBUILD.PackageDir,
-		".BUILDINFO"), tmpl)
-	if err != nil {
-		return err
-	}
+	return m.PKGBUILD.CreateSpec(
+		filepath.Join(m.PKGBUILD.PackageDir, ".BUILDINFO"), buildInfoTmpl)
+}
 
-	if m.PKGBUILD.StripEnabled {
-		err = options.Strip(m.PKGBUILD.PackageDir)
-		if err != nil {
-			return err
-		}
-	}
-
-	var mtreeEntries []*files.Entry
-
-	// Create file walker using common functionality
+// writeMTREE walks the package directory and writes a gzip-compressed .MTREE.
+func (m *Pkg) writeMTREE() error {
 	walker := m.CreateFileWalker()
 
-	// Walk through the package directory and retrieve the contents.
 	entries, err := walker.Walk()
 	if err != nil {
-		return err // Return the error if walking the directory fails.
+		return err
 	}
 
-	// Use entries directly
-	mtreeEntries = entries
-
-	mtreeFile, err := renderMtree(mtreeEntries)
+	mtreeFile, err := renderMtree(entries)
 	if err != nil {
 		return err
 	}
 
-	err = createMTREEGzip(mtreeFile,
-		filepath.Join(m.PKGBUILD.PackageDir, ".MTREE"))
+	return createMTREEGzip(mtreeFile, filepath.Join(m.PKGBUILD.PackageDir, ".MTREE"))
+}
+
+// writeInstallScriptIfNeeded writes the <pkgname>.install file when the
+// PKGBUILD declares any of the six scriptlet hooks.
+func (m *Pkg) writeInstallScriptIfNeeded() error {
+	if m.PKGBUILD.PreInst == "" && m.PKGBUILD.PostInst == "" &&
+		m.PKGBUILD.PreRm == "" && m.PKGBUILD.PostRm == "" &&
+		m.PKGBUILD.PreUpgrade == "" && m.PKGBUILD.PostUpgrade == "" {
+		return nil
+	}
+
+	tmpl := m.PKGBUILD.RenderSpec(postInstall)
+
+	return m.PKGBUILD.CreateSpec(
+		filepath.Join(m.pacmanDir, m.PKGBUILD.PkgName+".install"), tmpl)
+}
+
+// writeChangelogIfPresent writes a .CHANGELOG file in the package root when
+// the PKGBUILD declares a changelog source.
+func (m *Pkg) writeChangelogIfPresent() error {
+	changelogData, err := m.PKGBUILD.ReadChangelog()
 	if err != nil {
 		return err
 	}
 
-	tmpl = m.PKGBUILD.RenderSpec(postInstall)
-
-	err = m.PKGBUILD.CreateSpec(filepath.Join(m.pacmanDir,
-		m.PKGBUILD.PkgName+".install"), tmpl)
-	if err != nil {
-		return err
+	if changelogData == nil {
+		return nil
 	}
 
-	return nil
+	changelogPath := filepath.Join(m.PKGBUILD.PackageDir, ".CHANGELOG")
+
+	// nolint:gosec // .CHANGELOG matches Pacman world-readable convention
+	return os.WriteFile(filepath.Clean(changelogPath), changelogData, 0o644)
 }
 
 func renderMtree(entries []*files.Entry) (string, error) {

--- a/pkg/builders/pacman/makepkg_test.go
+++ b/pkg/builders/pacman/makepkg_test.go
@@ -68,7 +68,7 @@ func TestBuildPackage(t *testing.T) {
 		t.Fatalf("Failed to create artifacts dir: %v", err)
 	}
 
-	err = pkg.BuildPackage(artifactsDir, "")
+	_, err = pkg.BuildPackage(artifactsDir, "")
 	if err != nil {
 		t.Errorf("BuildPackage failed: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestBuildPackageWithoutEpoch(t *testing.T) {
 		t.Fatalf("Failed to create artifacts dir: %v", err)
 	}
 
-	err = pkg.BuildPackage(artifactsDir, "")
+	_, err = pkg.BuildPackage(artifactsDir, "")
 	if err != nil {
 		t.Errorf("BuildPackage failed: %v", err)
 	}
@@ -216,10 +216,10 @@ arch=('x86_64')
 		t.Error(".MTREE file was not created")
 	}
 
-	// Check that install script was created
+	// Check that install script was NOT created (no scriptlets in this test)
 	installPath := filepath.Join(startDir, "test-package.install")
-	if _, err := os.Stat(installPath); os.IsNotExist(err) {
-		t.Error("Install script was not created")
+	if _, err := os.Stat(installPath); err == nil {
+		t.Error("Install script should not be created when no scriptlets are present")
 	}
 }
 
@@ -426,5 +426,255 @@ func TestCreateMTREEGzip(t *testing.T) {
 
 	if info.Size() == 0 {
 		t.Error("MTREE file is empty")
+	}
+}
+
+func TestPrepareFakeroot_WithScriptlets(t *testing.T) {
+	pkgBuild := createTestPKGBUILD()
+	pkgBuild.PreInst = "echo 'pre-install'"
+	pkgBuild.PostInst = "echo 'post-install'"
+	pkgBuild.PreUpgrade = "echo 'pre-upgrade'"
+	pkgBuild.PostUpgrade = "echo 'post-upgrade'"
+	pkgBuild.PreRm = "echo 'pre-remove'"
+	pkgBuild.PostRm = "echo 'post-remove'"
+
+	pkg := NewBuilder(pkgBuild)
+
+	tempDir, err := os.MkdirTemp("", "pacman-scriptlet-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	// Create directories
+	startDir := filepath.Join(tempDir, "start")
+	packageDir := filepath.Join(tempDir, "package")
+
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatalf("Failed to create start dir: %v", err)
+	}
+
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatalf("Failed to create package dir: %v", err)
+	}
+
+	// Create a PKGBUILD file for checksum calculation
+	pkgbuildPath := filepath.Join(startDir, "PKGBUILD")
+	pkgbuildContent := `pkgname=test-package
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="Test package"
+arch=('x86_64')
+`
+
+	if err := os.WriteFile(pkgbuildPath, []byte(pkgbuildContent), 0o644); err != nil {
+		t.Fatalf("Failed to create PKGBUILD file: %v", err)
+	}
+
+	pkg.PKGBUILD.PackageDir = packageDir
+	pkg.PKGBUILD.StartDir = startDir
+	pkg.PKGBUILD.Home = startDir
+
+	artifactsDir := filepath.Join(tempDir, "artifacts")
+
+	if err := os.MkdirAll(artifactsDir, 0o755); err != nil {
+		t.Fatalf("Failed to create artifacts dir: %v", err)
+	}
+
+	err = pkg.PrepareFakeroot(artifactsDir, "x86_64")
+	if err != nil {
+		t.Errorf("PrepareFakeroot failed: %v", err)
+	}
+
+	// Check that .install file was created
+	installFile := filepath.Join(startDir, "test-package.install")
+	if _, err := os.Stat(installFile); os.IsNotExist(err) {
+		t.Errorf(".install file was not created: %s", installFile)
+	}
+
+	// Read and verify content
+	content, err := os.ReadFile(installFile)
+	if err != nil {
+		t.Errorf("Failed to read .install file: %v", err)
+	}
+
+	contentStr := string(content)
+
+	// Verify all scriptlet functions are present
+	if !strings.Contains(contentStr, "pre_install()") {
+		t.Error(".install file missing pre_install function")
+	}
+
+	if !strings.Contains(contentStr, "post_install()") {
+		t.Error(".install file missing post_install function")
+	}
+
+	if !strings.Contains(contentStr, "pre_upgrade()") {
+		t.Error(".install file missing pre_upgrade function")
+	}
+
+	if !strings.Contains(contentStr, "post_upgrade()") {
+		t.Error(".install file missing post_upgrade function")
+	}
+
+	if !strings.Contains(contentStr, "pre_remove()") {
+		t.Error(".install file missing pre_remove function")
+	}
+
+	if !strings.Contains(contentStr, "post_remove()") {
+		t.Error(".install file missing post_remove function")
+	}
+
+	// Verify scriptlet content
+	if !strings.Contains(contentStr, "echo 'pre-install'") {
+		t.Error(".install file missing pre_install content")
+	}
+
+	if !strings.Contains(contentStr, "echo 'post-install'") {
+		t.Error(".install file missing post_install content")
+	}
+
+	if !strings.Contains(contentStr, "echo 'pre-upgrade'") {
+		t.Error(".install file missing pre_upgrade content")
+	}
+
+	if !strings.Contains(contentStr, "echo 'post-upgrade'") {
+		t.Error(".install file missing post_upgrade content")
+	}
+}
+
+func TestPrepareFakeroot_WithoutScriptlets(t *testing.T) {
+	pkgBuild := createTestPKGBUILD()
+	// No scriptlets set
+
+	pkg := NewBuilder(pkgBuild)
+
+	tempDir, err := os.MkdirTemp("", "pacman-no-scriptlet-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	// Create directories
+	startDir := filepath.Join(tempDir, "start")
+	packageDir := filepath.Join(tempDir, "package")
+
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatalf("Failed to create start dir: %v", err)
+	}
+
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatalf("Failed to create package dir: %v", err)
+	}
+
+	// Create a PKGBUILD file for checksum calculation
+	pkgbuildPath := filepath.Join(startDir, "PKGBUILD")
+	pkgbuildContent := `pkgname=test-package
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="Test package"
+arch=('x86_64')
+`
+
+	if err := os.WriteFile(pkgbuildPath, []byte(pkgbuildContent), 0o644); err != nil {
+		t.Fatalf("Failed to create PKGBUILD file: %v", err)
+	}
+
+	pkg.PKGBUILD.PackageDir = packageDir
+	pkg.PKGBUILD.StartDir = startDir
+	pkg.PKGBUILD.Home = startDir
+
+	artifactsDir := filepath.Join(tempDir, "artifacts")
+
+	if err := os.MkdirAll(artifactsDir, 0o755); err != nil {
+		t.Fatalf("Failed to create artifacts dir: %v", err)
+	}
+
+	err = pkg.PrepareFakeroot(artifactsDir, "x86_64")
+	if err != nil {
+		t.Errorf("PrepareFakeroot failed: %v", err)
+	}
+
+	// Check that .install file was NOT created
+	installFile := filepath.Join(startDir, "test-package.install")
+	if _, err := os.Stat(installFile); err == nil {
+		t.Errorf(".install file should not be created when no scriptlets are present: %s", installFile)
+	}
+}
+
+func TestPrepareFakeroot_WithChangelog(t *testing.T) {
+	pkgBuild := createTestPKGBUILD()
+
+	tempDir, err := os.MkdirTemp("", "pacman-changelog-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	startDir := filepath.Join(tempDir, "start")
+	packageDir := filepath.Join(tempDir, "package")
+
+	err = os.MkdirAll(startDir, 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create start dir: %v", err)
+	}
+
+	err = os.MkdirAll(packageDir, 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create package dir: %v", err)
+	}
+
+	// Create a changelog file in the start directory
+	changelogPath := filepath.Join(startDir, "CHANGELOG.md")
+	changelogContent := "# Changelog\n\n## Version 1.0\n- Initial release\n"
+
+	err = os.WriteFile(changelogPath, []byte(changelogContent), 0o644)
+	if err != nil {
+		t.Fatalf("Failed to create changelog file: %v", err)
+	}
+
+	// Create a dummy PKGBUILD file
+	pkgbuildPath := filepath.Join(startDir, "PKGBUILD")
+
+	err = os.WriteFile(pkgbuildPath, []byte("# PKGBUILD\n"), 0o644)
+	if err != nil {
+		t.Fatalf("Failed to create PKGBUILD file: %v", err)
+	}
+
+	pkgBuild.StartDir = startDir
+	pkgBuild.Home = startDir // Same as StartDir to avoid PKGBUILD creation
+	pkgBuild.PackageDir = packageDir
+	pkgBuild.Changelog = "CHANGELOG.md"
+
+	pkg := NewBuilder(pkgBuild)
+
+	artifactsDir := filepath.Join(tempDir, "artifacts")
+
+	if err := os.MkdirAll(artifactsDir, 0o755); err != nil {
+		t.Fatalf("Failed to create artifacts dir: %v", err)
+	}
+
+	err = pkg.PrepareFakeroot(artifactsDir, "x86_64")
+	if err != nil {
+		t.Errorf("PrepareFakeroot failed: %v", err)
+	}
+
+	// Check that .CHANGELOG file was created
+	changelogFile := filepath.Join(packageDir, ".CHANGELOG")
+	if _, err := os.Stat(changelogFile); os.IsNotExist(err) {
+		t.Errorf(".CHANGELOG file was not created: %s", changelogFile)
+	}
+
+	// Verify the content
+	content, err := os.ReadFile(changelogFile)
+	if err != nil {
+		t.Errorf("Failed to read .CHANGELOG file: %v", err)
+	}
+
+	if string(content) != changelogContent {
+		t.Errorf("Changelog content mismatch. Expected %q, got %q", changelogContent, string(content))
 	}
 }

--- a/pkg/builders/rpm/rpm.go
+++ b/pkg/builders/rpm/rpm.go
@@ -27,17 +27,25 @@ const rootOwner = "root"
 // contains the metadata and build instructions for the package.
 type RPM struct {
 	*common.BaseBuilder
+	compression string
 }
 
-// NewBuilder creates a new RPM package builder.
-func NewBuilder(pkgBuild *pkgbuild.PKGBUILD) *RPM {
+// NewBuilder creates a new RPM package builder with optional compression setting.
+// If compression is empty, defaults to "zstd".
+func NewBuilder(pkgBuild *pkgbuild.PKGBUILD, compression string) *RPM {
+	if compression == "" {
+		compression = "zstd"
+	}
+
 	return &RPM{
 		BaseBuilder: common.NewBaseBuilder(pkgBuild, "rpm"),
+		compression: compression,
 	}
 }
 
 // BuildPackage creates an RPM package based on the provided PKGBUILD information.
-func (r *RPM) BuildPackage(artifactsPath string, targetArch string) error {
+// Returns the path to the created RPM file.
+func (r *RPM) BuildPackage(artifactsPath string, targetArch string) (string, error) {
 	r.LogCrossCompilation(targetArch)
 
 	// Use target architecture for cross-compilation if specified
@@ -75,7 +83,7 @@ func (r *RPM) BuildPackage(artifactsPath string, targetArch string) error {
 		URL:         r.PKGBUILD.URL,
 		Packager:    r.PKGBUILD.Maintainer,
 		Group:       r.PKGBUILD.Section,
-		Compressor:  "zstd",
+		Compressor:  r.compression,
 		Licence:     license,
 		Obsoletes:   r.processDepends(r.PKGBUILD.Replaces),
 		Provides:    r.processDepends(r.PKGBUILD.Provides),
@@ -85,22 +93,24 @@ func (r *RPM) BuildPackage(artifactsPath string, targetArch string) error {
 		BuildTime:   files.SourceDateEpochFromEnv(),
 	})
 	if err != nil {
-		return errors.Wrap(err, errors.ErrTypePackaging, "failed to create RPM metadata").
+		return "", errors.Wrap(err, errors.ErrTypePackaging, "failed to create RPM metadata").
 			WithOperation("BuildPackage")
 	}
 
 	err = r.createFilesInsideRPM(rpm)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	r.addScriptlets(rpm)
+
+	r.addChangelog(rpm)
 
 	cleanFilePath := filepath.Clean(pkgFilePath)
 
 	rpmFile, err := os.Create(cleanFilePath)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	defer func() {
@@ -113,13 +123,13 @@ func (r *RPM) BuildPackage(artifactsPath string, targetArch string) error {
 
 	err = rpm.Write(rpmFile)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Log package creation using common functionality
 	r.LogPackageCreated(cleanFilePath)
 
-	return nil
+	return cleanFilePath, nil
 }
 
 // PrepareFakeroot sets up the environment for building an RPM package in a fakeroot context.
@@ -231,6 +241,33 @@ func (r *RPM) addScriptlets(rpm *rpmpack.RPM) {
 	if r.PKGBUILD.PostTrans != "" {
 		rpm.AddPosttrans(withHelpers(r.PKGBUILD.PostTrans))
 	}
+}
+
+// addChangelog adds changelog entries to the RPM package if a changelog is
+// specified in the PKGBUILD. Currently, rpmpack does not expose a direct
+// changelog API, so this is a no-op with a warning log. Future versions may
+// use AddCustomTag to inject changelog entries via RPM tags.
+//
+// The rpm parameter is reserved for future use when rpmpack adds changelog API.
+func (r *RPM) addChangelog(_ *rpmpack.RPM) {
+	changelogData, err := r.PKGBUILD.ReadChangelog()
+	if err != nil {
+		logger.Warn("failed to read changelog for RPM package",
+			"error", err)
+
+		return
+	}
+
+	if changelogData == nil {
+		return
+	}
+
+	// Note: rpmpack v0.7.1 does not expose a direct changelog API.
+	// RPM changelog entries require specific formatting and tag injection.
+	// This is a limitation of the current rpmpack library.
+	// TODO: Implement changelog support when rpmpack adds the necessary API.
+	logger.Info("changelog specified but RPM changelog support not yet available",
+		"package", r.PKGBUILD.PkgName)
 }
 
 // asRPMDirectory creates an RPMFile object for a directory based on the provided Entry.

--- a/pkg/builders/rpm/rpm_test.go
+++ b/pkg/builders/rpm/rpm_test.go
@@ -83,7 +83,7 @@ func TestBuildPackage(t *testing.T) {
 		t.Fatalf("Failed to create artifacts dir: %v", err)
 	}
 
-	err = rpm.BuildPackage(artifactsDir, "")
+	_, err = rpm.BuildPackage(artifactsDir, "")
 	if err != nil {
 		t.Errorf("BuildPackage failed: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestBuildPackageWithoutEpoch(t *testing.T) {
 		t.Fatalf("Failed to create artifacts dir: %v", err)
 	}
 
-	err = rpm.BuildPackage(artifactsDir, "")
+	_, err = rpm.BuildPackage(artifactsDir, "")
 	if err != nil {
 		t.Errorf("BuildPackage failed: %v", err)
 	}

--- a/pkg/core/config.go
+++ b/pkg/core/config.go
@@ -133,3 +133,15 @@ var PackageManagerConfigs = map[string]*Config{
 func GetConfig(packageManager string) *Config {
 	return PackageManagerConfigs[packageManager]
 }
+
+// SigningConfig holds signing configuration for a project.
+type SigningConfig struct {
+	// Enabled indicates whether signing is active for this project.
+	Enabled bool `json:"enabled,omitempty"`
+	// KeyPath is the path to the private key file (PEM for RSA, ASCII-armored for GPG).
+	KeyPath string `json:"keyPath,omitempty"`
+	// Passphrase is the passphrase for the private key (discouraged in config; prefer env vars).
+	Passphrase string `json:"passphrase,omitempty"`
+	// KeyName is optional, used for APK key naming (e.g., "mykey").
+	KeyName string `json:"keyName,omitempty"`
+}

--- a/pkg/i18n/locales/en.yaml
+++ b/pkg/i18n/locales/en.yaml
@@ -166,6 +166,22 @@
   translation: "Stop building at this distribution"
 - id: flags.build.zap
   translation: "Clean artifacts before building"
+- id: flags.build.sbom
+  translation: "Generate Software Bill of Materials (SBOM) for packages"
+- id: flags.build.sbom_format
+  translation: "SBOM format(s) to generate (cyclonedx, spdx, both)"
+- id: flags.build.compression_deb
+  translation: "DEB compression algorithm (zstd, gzip, xz)"
+- id: flags.build.compression_rpm
+  translation: "RPM compression algorithm (zstd, gzip, xz)"
+- id: flags.build.sign
+  translation: "Enable package signing"
+- id: flags.build.sign_key
+  translation: "Path to private key for signing (PEM for RSA, ASCII-armored for GPG)"
+- id: flags.build.sign_passphrase
+  translation: "Passphrase for private key (prefer env var YAP_SIGN_PASSPHRASE)"
+- id: flags.build.sign_key_name
+  translation: "Key name for APK signing (e.g., 'mykey')"
 
 # Graph flags
 - id: flags.graph.format
@@ -888,3 +904,13 @@
   translation: "Extraction complete"
 - id: logger.extract.extracting_to_sysroot
   translation: "Extracting package to sysroot"
+
+# Logger messages - SBOM generation
+- id: logger.sbom_generated
+  translation: "SBOM generated successfully"
+- id: logger.sbom_generation_failed
+  translation: "Failed to generate SBOM"
+
+# Logger messages - Package signing
+- id: logger.signing_artifact
+  translation: "Signing package artifact"

--- a/pkg/i18n/locales/it.yaml
+++ b/pkg/i18n/locales/it.yaml
@@ -167,6 +167,22 @@
   translation: "Ferma la compilazione a questa distribuzione"
 - id: flags.build.zap
   translation: "Pulisce gli artefatti prima della compilazione"
+- id: flags.build.sbom
+  translation: "Genera Software Bill of Materials (SBOM) per i pacchetti"
+- id: flags.build.sbom_format
+  translation: "Formato(i) SBOM da generare (cyclonedx, spdx, both)"
+- id: flags.build.compression_deb
+  translation: "Algoritmo di compressione DEB (zstd, gzip, xz)"
+- id: flags.build.compression_rpm
+  translation: "Algoritmo di compressione RPM (zstd, gzip, xz)"
+- id: flags.build.sign
+  translation: "Abilita la firma dei pacchetti"
+- id: flags.build.sign_key
+  translation: "Percorso della chiave privata per la firma (PEM per RSA, ASCII-armored per GPG)"
+- id: flags.build.sign_passphrase
+  translation: "Passphrase per la chiave privata (preferire la variabile d'ambiente YAP_SIGN_PASSPHRASE)"
+- id: flags.build.sign_key_name
+  translation: "Nome della chiave per la firma APK (es. 'mykey')"
 
 # Flag graph
 - id: flags.graph.format
@@ -889,3 +905,13 @@
   translation: "Tutti i pacchetti richiesti sono già installati"
 - id: logger.pkgbuild.info.packages_already_installed
   translation: "Alcuni pacchetti sono già installati"
+
+# Logger messages - SBOM
+- id: logger.sbom_generated
+  translation: "SBOM generato con successo"
+- id: logger.sbom_generation_failed
+  translation: "Generazione SBOM non riuscita"
+
+# Logger messages - Package signing
+- id: logger.signing_artifact
+  translation: "Firma artefatto del pacchetto"

--- a/pkg/packer/packer.go
+++ b/pkg/packer/packer.go
@@ -23,8 +23,9 @@ type InstallOrExtractor interface {
 // Packer is the common interface implemented by all package managers.
 type Packer interface {
 	// BuildPackage starts the package building process and writes the final artifact
-	// to the specified output path. It returns an error if any issues occur during the build.
-	BuildPackage(output string, targetArch string) error
+	// to the specified output path. It returns the path to the built artifact and an error
+	// if any issues occur during the build.
+	BuildPackage(output string, targetArch string) (string, error)
 	// Prepare appends the dependencies required to build all the projects. It
 	// returns any error if encountered.
 	Prepare(depends []string, targetArch string) error
@@ -44,8 +45,15 @@ type Packer interface {
 //
 // pkgBuild: A pointer to a pkgbuild.PKGBUILD struct.
 // distro: A string representing the distribution.
+// compressionDeb: Compression algorithm for DEB packages (empty string uses default).
+// compressionRpm: Compression algorithm for RPM packages (empty string uses default).
 // Returns a Packer interface.
-func GetPackageManager(pkgBuild *pkgbuild.PKGBUILD, distro string) Packer {
+func GetPackageManager(
+	pkgBuild *pkgbuild.PKGBUILD,
+	distro string,
+	compressionDeb string,
+	compressionRpm string,
+) Packer {
 	pkgManager := constants.DistroToPackageManager[distro]
 
 	// Get configuration for the package manager
@@ -59,13 +67,13 @@ func GetPackageManager(pkgBuild *pkgbuild.PKGBUILD, distro string) Packer {
 	case "apk":
 		return apk.NewBuilder(pkgBuild)
 	case "apt":
-		return deb.NewBuilder(pkgBuild)
+		return deb.NewBuilder(pkgBuild, compressionDeb)
 	case "pacman":
 		return pacman.NewBuilder(pkgBuild)
 	case "yum":
-		return rpm.NewBuilder(pkgBuild)
+		return rpm.NewBuilder(pkgBuild, compressionRpm)
 	case "zypper":
-		return rpm.NewBuilder(pkgBuild)
+		return rpm.NewBuilder(pkgBuild, compressionRpm)
 	default:
 		logger.Fatal(i18n.T("errors.packer.unsupported_linux_distro"),
 			"distro", distro)

--- a/pkg/packer/packer_test.go
+++ b/pkg/packer/packer_test.go
@@ -16,7 +16,7 @@ func TestGetPackageManager_APK(t *testing.T) {
 		PkgVer:  "1.0.0",
 	}
 
-	packer := GetPackageManager(pkgBuild, "alpine")
+	packer := GetPackageManager(pkgBuild, "alpine", "", "")
 
 	if packer == nil {
 		t.Fatal("GetPackageManager returned nil for alpine")
@@ -38,7 +38,7 @@ func TestGetPackageManager_DEB(t *testing.T) {
 
 	for _, distro := range debDistros {
 		t.Run(distro, func(t *testing.T) {
-			packer := GetPackageManager(pkgBuild, distro)
+			packer := GetPackageManager(pkgBuild, distro, "", "")
 
 			if packer == nil {
 				t.Fatalf("GetPackageManager returned nil for %s", distro)
@@ -58,7 +58,7 @@ func TestGetPackageManager_PKG(t *testing.T) {
 		PkgVer:  "1.0.0",
 	}
 
-	packer := GetPackageManager(pkgBuild, "arch")
+	packer := GetPackageManager(pkgBuild, "arch", "", "")
 
 	if packer == nil {
 		t.Fatal("GetPackageManager returned nil for arch")
@@ -80,7 +80,7 @@ func TestGetPackageManager_RPM_YUM(t *testing.T) {
 
 	for _, distro := range yumDistros {
 		t.Run(distro, func(t *testing.T) {
-			packer := GetPackageManager(pkgBuild, distro)
+			packer := GetPackageManager(pkgBuild, distro, "", "")
 
 			if packer == nil {
 				t.Fatalf("GetPackageManager returned nil for %s", distro)
@@ -100,7 +100,7 @@ func TestGetPackageManager_RPM_Zypper(t *testing.T) {
 		PkgVer:  "1.0.0",
 	}
 
-	packer := GetPackageManager(pkgBuild, "opensuse-leap")
+	packer := GetPackageManager(pkgBuild, "opensuse-leap", "", "")
 
 	if packer == nil {
 		t.Fatal("GetPackageManager returned nil for opensuse-leap")
@@ -134,7 +134,7 @@ func TestGetPackageManager_Integration(t *testing.T) {
 
 	for distro, expectedType := range testCases {
 		t.Run(distro, func(t *testing.T) {
-			packer := GetPackageManager(pkgBuild, distro)
+			packer := GetPackageManager(pkgBuild, distro, "", "")
 
 			if packer == nil {
 				t.Fatalf("GetPackageManager returned nil for %s", distro)
@@ -191,7 +191,7 @@ func TestGetPackageManager_ValidatesInterface(t *testing.T) {
 
 	for _, distro := range distros {
 		t.Run(distro, func(t *testing.T) {
-			packer := GetPackageManager(pkgBuild, distro)
+			packer := GetPackageManager(pkgBuild, distro, "", "")
 
 			if packer == nil {
 				t.Fatalf("GetPackageManager returned nil for %s", distro)

--- a/pkg/parser/additional_parser_test.go
+++ b/pkg/parser/additional_parser_test.go
@@ -198,3 +198,109 @@ func TestParseFileErrors(t *testing.T) {
 		t.Error("ParseFile() should return error for invalid home directory")
 	}
 }
+
+func TestParseFileWithUpgradeScriptlets(t *testing.T) {
+	// Create a temporary directory with a PKGBUILD file containing upgrade scriptlets
+	tempDir := t.TempDir()
+
+	pkgbuildContent := `# Test PKGBUILD with upgrade scriptlets
+pkgname="test-upgrade"
+pkgver="1.0.0"
+pkgrel="1"
+pkgdesc="A test package with upgrade scriptlets"
+arch=("x86_64")
+url="https://example.com"
+license=("MIT")
+
+preinst() {
+    echo "Running pre-install"
+}
+
+postinst() {
+    echo "Running post-install"
+}
+
+pre_upgrade() {
+    echo "Running pre-upgrade"
+}
+
+post_upgrade() {
+    echo "Running post-upgrade"
+}
+
+prerm() {
+    echo "Running pre-remove"
+}
+
+postrm() {
+    echo "Running post-remove"
+}
+
+package() {
+    mkdir -p "${pkgdir}/usr/bin"
+    echo "test" > "${pkgdir}/usr/bin/test"
+}
+`
+
+	pkgbuildPath := filepath.Join(tempDir, "PKGBUILD")
+
+	err := os.WriteFile(pkgbuildPath, []byte(pkgbuildContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to write PKGBUILD: %v", err)
+	}
+
+	// Test parsing
+	pkgBuild, err := parser.ParseFile("arch", "", tempDir, tempDir)
+	if err != nil {
+		t.Fatalf("ParseFile() error = %v", err)
+	}
+
+	// Verify scriptlet fields
+	if pkgBuild.PreInst == "" {
+		t.Error("PreInst should not be empty")
+	}
+
+	if !strings.Contains(pkgBuild.PreInst, "pre-install") {
+		t.Errorf("PreInst should contain 'pre-install', got '%s'", pkgBuild.PreInst)
+	}
+
+	if pkgBuild.PostInst == "" {
+		t.Error("PostInst should not be empty")
+	}
+
+	if !strings.Contains(pkgBuild.PostInst, "post-install") {
+		t.Errorf("PostInst should contain 'post-install', got '%s'", pkgBuild.PostInst)
+	}
+
+	if pkgBuild.PreUpgrade == "" {
+		t.Error("PreUpgrade should not be empty")
+	}
+
+	if !strings.Contains(pkgBuild.PreUpgrade, "pre-upgrade") {
+		t.Errorf("PreUpgrade should contain 'pre-upgrade', got '%s'", pkgBuild.PreUpgrade)
+	}
+
+	if pkgBuild.PostUpgrade == "" {
+		t.Error("PostUpgrade should not be empty")
+	}
+
+	if !strings.Contains(pkgBuild.PostUpgrade, "post-upgrade") {
+		t.Errorf("PostUpgrade should contain 'post-upgrade', got '%s'", pkgBuild.PostUpgrade)
+	}
+
+	if pkgBuild.PreRm == "" {
+		t.Error("PreRm should not be empty")
+	}
+
+	if !strings.Contains(pkgBuild.PreRm, "pre-remove") {
+		t.Errorf("PreRm should contain 'pre-remove', got '%s'", pkgBuild.PreRm)
+	}
+
+	if pkgBuild.PostRm == "" {
+		t.Error("PostRm should not be empty")
+	}
+
+	if !strings.Contains(pkgBuild.PostRm, "post-remove") {
+		t.Errorf("PostRm should contain 'post-remove', got '%s'", pkgBuild.PostRm)
+	}
+}

--- a/pkg/pkgbuild/changelog.go
+++ b/pkg/pkgbuild/changelog.go
@@ -1,0 +1,36 @@
+// Package pkgbuild provides PKGBUILD structure and manipulation functionality.
+package pkgbuild
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/M0Rf30/yap/v2/pkg/errors"
+)
+
+// ReadChangelog returns the changelog file contents, resolved relative to the
+// PKGBUILD directory. Returns empty bytes and nil error if Changelog is empty.
+// Returns wrapped error if the path is set but the file is unreadable.
+func (pkgBuild *PKGBUILD) ReadChangelog() ([]byte, error) {
+	if pkgBuild.Changelog == "" {
+		return nil, nil
+	}
+
+	// Resolve path relative to StartDir (where PKGBUILD is located)
+	changelogPath := pkgBuild.Changelog
+	if !filepath.IsAbs(changelogPath) {
+		changelogPath = filepath.Join(pkgBuild.StartDir, pkgBuild.Changelog)
+	}
+
+	changelogPath = filepath.Clean(changelogPath)
+
+	data, err := os.ReadFile(changelogPath) //nolint:gosec // path resolved from trusted PKGBUILD
+	if err != nil {
+		return nil, errors.Wrap(err, errors.ErrTypeFileSystem,
+			"failed to read changelog file").
+			WithOperation("ReadChangelog").
+			WithContext("path", changelogPath)
+	}
+
+	return data, nil
+}

--- a/pkg/pkgbuild/changelog_test.go
+++ b/pkg/pkgbuild/changelog_test.go
@@ -1,0 +1,87 @@
+package pkgbuild
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadChangelog_Empty(t *testing.T) {
+	p := &PKGBUILD{
+		Changelog: "",
+		StartDir:  "/tmp",
+	}
+
+	data, err := p.ReadChangelog()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if data != nil {
+		t.Fatalf("expected nil data, got %v", data)
+	}
+}
+
+func TestReadChangelog_FileNotFound(t *testing.T) {
+	p := &PKGBUILD{
+		Changelog: "nonexistent.txt",
+		StartDir:  "/tmp",
+	}
+
+	_, err := p.ReadChangelog()
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+func TestReadChangelog_Success(t *testing.T) {
+	// Create a temporary directory and file
+	tmpDir := t.TempDir()
+	changelogPath := filepath.Join(tmpDir, "CHANGELOG.md")
+	changelogContent := "# Changelog\n\n## Version 1.0\n- Initial release\n"
+
+	err := os.WriteFile(changelogPath, []byte(changelogContent), 0o644)
+	if err != nil {
+		t.Fatalf("failed to create test changelog: %v", err)
+	}
+
+	p := &PKGBUILD{
+		Changelog: "CHANGELOG.md",
+		StartDir:  tmpDir,
+	}
+
+	data, err := p.ReadChangelog()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if string(data) != changelogContent {
+		t.Fatalf("expected %q, got %q", changelogContent, string(data))
+	}
+}
+
+func TestReadChangelog_AbsolutePath(t *testing.T) {
+	// Create a temporary directory and file
+	tmpDir := t.TempDir()
+	changelogPath := filepath.Join(tmpDir, "CHANGELOG.md")
+	changelogContent := "# Changelog\n\n## Version 1.0\n- Initial release\n"
+
+	err := os.WriteFile(changelogPath, []byte(changelogContent), 0o644)
+	if err != nil {
+		t.Fatalf("failed to create test changelog: %v", err)
+	}
+
+	p := &PKGBUILD{
+		Changelog: changelogPath,
+		StartDir:  "/some/other/dir",
+	}
+
+	data, err := p.ReadChangelog()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if string(data) != changelogContent {
+		t.Fatalf("expected %q, got %q", changelogContent, string(data))
+	}
+}

--- a/pkg/pkgbuild/pkgbuild.go
+++ b/pkg/pkgbuild/pkgbuild.go
@@ -93,6 +93,7 @@ type PKGBUILD struct {
 	Build           string
 	BuildArch       string // Build architecture for cross-compilation (where compilation happens)
 	BuildDate       int64
+	Changelog       string `json:"changelog,omitempty"`
 	Checksum        string
 	Codename        string
 	Commit          string
@@ -132,11 +133,13 @@ type PKGBUILD struct {
 	PostInst        string
 	PostRm          string
 	PostTrans       string
+	PostUpgrade     string
 	PreInst         string
 	Prepare         string
 	PreRelease      string
 	PreRm           string
 	PreTrans        string
+	PreUpgrade      string
 	priorities      map[string]int
 	Priority        string
 	Provides        []string
@@ -1035,6 +1038,10 @@ func (pkgBuild *PKGBUILD) mapFunctions(key string, data any) {
 		pkgBuild.PreTrans = body
 	case "postrm":
 		pkgBuild.PostRm = body
+	case "pre_upgrade":
+		pkgBuild.PreUpgrade = body
+	case "post_upgrade":
+		pkgBuild.PostUpgrade = body
 	default:
 		// Store any other function (e.g. _package, _package_systemd, _install_helper)
 		// as a helper. The full definition is reconstructed so it can be prepended to
@@ -1159,6 +1166,13 @@ func (pkgBuild *PKGBUILD) mapVariables(key string, data any) {
 		}
 
 		pkgBuild.Install = strVal
+	case "changelog":
+		strVal, ok := data.(string)
+		if !ok {
+			return
+		}
+
+		pkgBuild.Changelog = strVal
 	case "target_arch":
 		strVal, ok := data.(string)
 		if !ok {

--- a/pkg/pkgbuild/pkgbuild_test.go
+++ b/pkg/pkgbuild/pkgbuild_test.go
@@ -66,6 +66,26 @@ func TestPKGBUILD_AddItem(t *testing.T) {
 	if pb.Build != "make && make install" {
 		t.Errorf("Expected Build 'make && make install', got '%s'", pb.Build)
 	}
+
+	// Test adding pre_upgrade function
+	err = pb.AddItem("pre_upgrade", FuncBody("echo 'pre-upgrade'"))
+	if err != nil {
+		t.Errorf("AddItem() returned error: %v", err)
+	}
+
+	if pb.PreUpgrade != "echo 'pre-upgrade'" {
+		t.Errorf("Expected PreUpgrade 'echo 'pre-upgrade'', got '%s'", pb.PreUpgrade)
+	}
+
+	// Test adding post_upgrade function
+	err = pb.AddItem("post_upgrade", FuncBody("echo 'post-upgrade'"))
+	if err != nil {
+		t.Errorf("AddItem() returned error: %v", err)
+	}
+
+	if pb.PostUpgrade != "echo 'post-upgrade'" {
+		t.Errorf("Expected PostUpgrade 'echo 'post-upgrade'', got '%s'", pb.PostUpgrade)
+	}
 }
 
 func TestPKGBUILD_ComputeArchitecture(t *testing.T) {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -2,6 +2,7 @@
 package project
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,6 +18,7 @@ import (
 	"github.com/otiai10/copy"
 
 	"github.com/M0Rf30/yap/v2/pkg/builder"
+	"github.com/M0Rf30/yap/v2/pkg/core"
 	yerrors "github.com/M0Rf30/yap/v2/pkg/errors"
 	"github.com/M0Rf30/yap/v2/pkg/files"
 	"github.com/M0Rf30/yap/v2/pkg/i18n"
@@ -25,6 +27,8 @@ import (
 	"github.com/M0Rf30/yap/v2/pkg/packer"
 	"github.com/M0Rf30/yap/v2/pkg/parser"
 	"github.com/M0Rf30/yap/v2/pkg/pkgbuild"
+	"github.com/M0Rf30/yap/v2/pkg/sbom"
+	"github.com/M0Rf30/yap/v2/pkg/signing"
 )
 
 var (
@@ -68,6 +72,12 @@ var (
 	// When set, debug info is extracted from ELF binaries before stripping
 	// and saved in a .build-id directory structure suitable for debuginfod.
 	DebugDir string
+	// SBOM enables Software Bill of Materials generation.
+	// When true, SBOM files are generated for each built package.
+	SBOM bool
+	// SBOMFormat specifies the SBOM format(s) to generate.
+	// Valid values: "cyclonedx", "spdx", "both" (default: "both").
+	SBOMFormat string
 
 	// Global state variables
 	singleProject  bool
@@ -134,11 +144,14 @@ type DistroProject interface {
 // packages and the ToPkgName field, which can be used to stop the build
 // process after a specific package.
 type MultipleProject struct {
-	BuildDir    string     `json:"buildDir"    validate:"required"`
-	Description string     `json:"description" validate:"required"`
-	Name        string     `json:"name"        validate:"required"`
-	Output      string     `json:"output"      validate:"required"`
-	Projects    []*Project `json:"projects"    validate:"required,dive,required"`
+	BuildDir       string              `json:"buildDir"       validate:"required"`
+	Description    string              `json:"description"    validate:"required"`
+	Name           string              `json:"name"           validate:"required"`
+	Output         string              `json:"output"         validate:"required"`
+	Projects       []*Project          `json:"projects"       validate:"required,dive,required"`
+	CompressionDeb string              `json:"compressionDeb" validate:""`
+	CompressionRpm string              `json:"compressionRpm" validate:""`
+	Signing        *core.SigningConfig `json:"signing,omitempty"`
 }
 
 // Project represents a single project.
@@ -157,6 +170,9 @@ type Project struct {
 	Root           string
 	Name           string `json:"name"    validate:"required,startsnotwith=.,startsnotwith=./"`
 	HasToInstall   bool   `json:"install" validate:""`
+	CompressionDeb string
+	CompressionRpm string
+	Signing        *core.SigningConfig
 }
 
 // BuildAll builds all projects in the correct order.
@@ -238,7 +254,7 @@ func (mpc *MultipleProject) MultiProject(distro, release, path string) error {
 		return err
 	}
 
-	packageManager = packer.GetPackageManager(&pkgbuild.PKGBUILD{}, distro)
+	packageManager = packer.GetPackageManager(&pkgbuild.PKGBUILD{}, distro, "", "")
 	if !SkipSyncDeps {
 		err := packageManager.Update()
 		if err != nil {
@@ -620,9 +636,29 @@ func (mpc *MultipleProject) createPackage(proj *Project) error {
 		"version", proj.Builder.PKGBUILD.PkgVer,
 		"release", proj.Builder.PKGBUILD.PkgRel)
 
-	err = proj.PackageManager.BuildPackage(mpc.Output, TargetArch)
+	artifactPath, err := proj.PackageManager.BuildPackage(mpc.Output, TargetArch)
 	if err != nil {
 		return err
+	}
+
+	return mpc.runPostBuildHooks(proj, artifactPath)
+}
+
+// runPostBuildHooks executes signing and SBOM generation after a successful
+// package build. Signing failures abort the build; SBOM failures only warn.
+func (mpc *MultipleProject) runPostBuildHooks(proj *Project, artifactPath string) error {
+	if proj.Signing != nil && proj.Signing.Enabled && artifactPath != "" {
+		if err := mpc.signArtifact(proj, artifactPath); err != nil {
+			return err
+		}
+	}
+
+	if SBOM {
+		if err := mpc.generateSBOM(proj, mpc.Output); err != nil {
+			logger.Warn(i18n.T("logger.sbom_generation_failed"),
+				"package", proj.Builder.PKGBUILD.PkgName,
+				"error", err)
+		}
 	}
 
 	return nil
@@ -775,13 +811,16 @@ func (mpc *MultipleProject) populateProjects(distro, release, path string) error
 			return err
 		}
 
-		packageManager = packer.GetPackageManager(pkgbuildFile, distro)
+		packageManager = packer.GetPackageManager(pkgbuildFile, distro,
+			mpc.CompressionDeb, mpc.CompressionRpm)
 
 		proj := &Project{
 			Name:           child.Name,
 			Builder:        &builder.Builder{PKGBUILD: pkgbuildFile},
 			PackageManager: packageManager,
 			HasToInstall:   child.HasToInstall,
+			CompressionDeb: mpc.CompressionDeb,
+			CompressionRpm: mpc.CompressionRpm,
 		}
 
 		projects = append(projects, proj)
@@ -1609,4 +1648,164 @@ func (mpc *MultipleProject) buildProjectsInOrder(buildOrder [][]*Project, maxWor
 	}
 
 	return nil
+}
+
+// signArtifact signs a built package artifact based on its file extension
+// and the project's signing configuration.
+func (mpc *MultipleProject) signArtifact(proj *Project, artifactPath string) error {
+	format, ok := signingFormatForArtifact(artifactPath)
+	if !ok {
+		// Unknown extension; nothing to sign
+		return nil
+	}
+
+	cfg := signing.Config{
+		Enabled:    proj.Signing.Enabled,
+		KeyPath:    proj.Signing.KeyPath,
+		Passphrase: proj.Signing.Passphrase,
+		KeyName:    proj.Signing.KeyName,
+	}
+
+	signer, err := signing.NewSigner(format, cfg)
+	if err != nil {
+		return yerrors.Wrap(err, yerrors.ErrTypeBuild, "failed to create signer").
+			WithOperation("signArtifact").
+			WithContext("artifact", artifactPath).
+			WithContext("format", string(format))
+	}
+
+	logger.Info(i18n.T("logger.signing_artifact"),
+		"package", proj.Builder.PKGBUILD.PkgName,
+		"artifact", artifactPath,
+		"format", string(format))
+
+	if err := signer.Sign(context.Background(), artifactPath); err != nil {
+		return yerrors.Wrap(err, yerrors.ErrTypeBuild, "failed to sign artifact").
+			WithOperation("signArtifact").
+			WithContext("artifact", artifactPath).
+			WithContext("format", string(format))
+	}
+
+	return nil
+}
+
+// signingFormatForArtifact maps a file extension to a signing.Format.
+func signingFormatForArtifact(artifactPath string) (signing.Format, bool) {
+	lower := strings.ToLower(artifactPath)
+	switch {
+	case strings.HasSuffix(lower, ".apk"):
+		return signing.FormatAPK, true
+	case strings.HasSuffix(lower, ".deb"):
+		return signing.FormatDEB, true
+	case strings.HasSuffix(lower, ".rpm"):
+		return signing.FormatRPM, true
+	case strings.HasSuffix(lower, ".pkg.tar.zst"),
+		strings.HasSuffix(lower, ".pkg.tar.xz"),
+		strings.HasSuffix(lower, ".pkg.tar.gz"):
+		return signing.FormatPacman, true
+	}
+
+	return "", false
+}
+
+// generateSBOM generates Software Bill of Materials for a built package.
+// It finds the artifact file in the output directory and generates SBOM
+// sidecars in the requested format(s).
+func (mpc *MultipleProject) generateSBOM(proj *Project, outputDir string) error {
+	// Parse SBOM format flag
+	var formats []sbom.Format
+
+	switch strings.ToLower(SBOMFormat) {
+	case "cyclonedx":
+		formats = []sbom.Format{sbom.FormatCycloneDX}
+	case "spdx":
+		formats = []sbom.Format{sbom.FormatSPDX}
+	case "both", "":
+		formats = []sbom.Format{sbom.FormatCycloneDX, sbom.FormatSPDX}
+	default:
+		return yerrors.New(yerrors.ErrTypeConfiguration,
+			fmt.Sprintf("invalid SBOM format: %s", SBOMFormat)).
+			WithOperation("generateSBOM").
+			WithContext("format", SBOMFormat)
+	}
+
+	// Find the artifact file(s) in the output directory
+	// The artifact naming convention depends on the package format
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		return yerrors.Wrap(err, yerrors.ErrTypeBuild,
+			"failed to read output directory").
+			WithOperation("generateSBOM").
+			WithContext("output_dir", outputDir)
+	}
+
+	// Look for recently created artifact files matching the package
+	pkgName := proj.Builder.PKGBUILD.PkgName
+	pkgVer := proj.Builder.PKGBUILD.PkgVer
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		fileName := entry.Name()
+
+		// Check if this is an artifact for our package
+		// Artifacts typically follow pattern: pkgname-version-release-arch.ext
+		if !strings.Contains(fileName, pkgName) ||
+			!strings.Contains(fileName, pkgVer) {
+			continue
+		}
+
+		// Skip SBOM files themselves
+		if strings.HasSuffix(fileName, ".cdx.json") ||
+			strings.HasSuffix(fileName, ".spdx.json") {
+			continue
+		}
+
+		// Check if it's a package artifact (deb, rpm, apk, pkg.tar.*)
+		if !isPackageArtifact(fileName) {
+			continue
+		}
+
+		artifactPath := filepath.Join(outputDir, fileName)
+
+		// Generate SBOM
+		opts := sbom.Options{Formats: formats}
+
+		_, err := sbom.Generate(proj.Builder.PKGBUILD, artifactPath, opts)
+		if err != nil {
+			return yerrors.Wrap(err, yerrors.ErrTypeBuild,
+				"failed to generate SBOM").
+				WithOperation("generateSBOM").
+				WithContext("artifact", fileName)
+		}
+
+		logger.Debug(i18n.T("logger.sbom_generated"),
+			"package", pkgName,
+			"artifact", fileName)
+	}
+
+	return nil
+}
+
+// isPackageArtifact checks if a filename is a package artifact.
+func isPackageArtifact(fileName string) bool {
+	packageExtensions := []string{
+		".deb",
+		".rpm",
+		".apk",
+		".pkg.tar.zst",
+		".pkg.tar.xz",
+		".pkg.tar.gz",
+		".pkg.tar",
+	}
+
+	for _, ext := range packageExtensions {
+		if strings.HasSuffix(fileName, ext) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/sbom/cyclonedx.go
+++ b/pkg/sbom/cyclonedx.go
@@ -1,0 +1,194 @@
+package sbom
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/M0Rf30/yap/v2/pkg/pkgbuild"
+)
+
+// componentTypeLibrary is the CycloneDX component type for library packages.
+const componentTypeLibrary = "library"
+
+// CycloneDXBOM represents a CycloneDX 1.5 Bill of Materials.
+type CycloneDXBOM struct {
+	BOMFormat          string                 `json:"bomFormat"`
+	SpecVersion        string                 `json:"specVersion"`
+	SerialNumber       string                 `json:"serialNumber"`
+	Version            int                    `json:"version"`
+	Metadata           *CycloneDXMetadata     `json:"metadata,omitempty"`
+	Components         []*CycloneDXComponent  `json:"components,omitempty"`
+	Dependencies       []*CycloneDXDependency `json:"dependencies,omitempty"`
+	ExternalReferences []*CycloneDXExtRef     `json:"externalReferences,omitempty"`
+}
+
+// CycloneDXMetadata represents metadata in CycloneDX BOM.
+type CycloneDXMetadata struct {
+	Timestamp string              `json:"timestamp,omitempty"`
+	Component *CycloneDXComponent `json:"component,omitempty"`
+}
+
+// CycloneDXComponent represents a component in CycloneDX BOM.
+type CycloneDXComponent struct {
+	Type               string              `json:"type"`
+	Name               string              `json:"name"`
+	Version            string              `json:"version,omitempty"`
+	Description        string              `json:"description,omitempty"`
+	Licenses           []*CycloneDXLicense `json:"licenses,omitempty"`
+	Purl               string              `json:"purl,omitempty"`
+	ExternalReferences []*CycloneDXExtRef  `json:"externalReferences,omitempty"`
+	Hashes             []*CycloneDXHash    `json:"hashes,omitempty"`
+}
+
+// CycloneDXLicense represents a license in CycloneDX BOM.
+type CycloneDXLicense struct {
+	License *CycloneDXLicenseChoice `json:"license,omitempty"`
+}
+
+// CycloneDXLicenseChoice represents a license choice.
+type CycloneDXLicenseChoice struct {
+	Name string `json:"name,omitempty"`
+	ID   string `json:"id,omitempty"`
+}
+
+// CycloneDXHash represents a hash in CycloneDX BOM.
+type CycloneDXHash struct {
+	Alg   string `json:"alg"`
+	Value string `json:"content"`
+}
+
+// CycloneDXExtRef represents an external reference in CycloneDX BOM.
+type CycloneDXExtRef struct {
+	Type   string           `json:"type"`
+	URL    string           `json:"url"`
+	Hashes []*CycloneDXHash `json:"hashes,omitempty"`
+}
+
+// CycloneDXDependency represents a dependency in CycloneDX BOM.
+type CycloneDXDependency struct {
+	Ref     string   `json:"ref"`
+	Depends []string `json:"depends,omitempty"`
+}
+
+// generateCycloneDX generates a CycloneDX 1.5 SBOM for the given package.
+func generateCycloneDX(pkg *pkgbuild.PKGBUILD) *CycloneDXBOM {
+	bom := &CycloneDXBOM{
+		BOMFormat:    "CycloneDX",
+		SpecVersion:  "1.5",
+		SerialNumber: fmt.Sprintf("urn:uuid:yap-%s-%s", pkg.PkgName, pkg.PkgVer),
+		Version:      1,
+	}
+
+	// Create main component
+	mainComponent := &CycloneDXComponent{
+		Type:        componentTypeLibrary,
+		Name:        pkg.PkgName,
+		Version:     pkg.PkgVer,
+		Description: pkg.PkgDesc,
+		Purl:        generatePurl(pkg),
+	}
+
+	// Add licenses
+	for _, license := range pkg.License {
+		mainComponent.Licenses = append(mainComponent.Licenses, &CycloneDXLicense{
+			License: &CycloneDXLicenseChoice{
+				Name: license,
+			},
+		})
+	}
+
+	// Add external references for source URLs
+	for _, sourceURL := range pkg.SourceURI {
+		mainComponent.ExternalReferences = append(
+			mainComponent.ExternalReferences,
+			&CycloneDXExtRef{
+				Type: "distribution",
+				URL:  sourceURL,
+			},
+		)
+	}
+
+	// Set metadata
+	bom.Metadata = &CycloneDXMetadata{
+		Component: mainComponent,
+	}
+
+	// Add runtime dependencies as components
+	depComponents := make(map[string]*CycloneDXComponent)
+
+	for _, dep := range pkg.Depends {
+		depName := extractDepName(dep)
+		if depName == "" {
+			continue
+		}
+
+		component := &CycloneDXComponent{
+			Type: componentTypeLibrary,
+			Name: depName,
+			Purl: fmt.Sprintf("pkg:generic/%s", depName),
+		}
+		depComponents[depName] = component
+		bom.Components = append(bom.Components, component)
+	}
+
+	// Add make dependencies as optional components
+	for _, dep := range pkg.MakeDepends {
+		depName := extractDepName(dep)
+		if depName == "" || depComponents[depName] != nil {
+			continue
+		}
+
+		component := &CycloneDXComponent{
+			Type: componentTypeLibrary,
+			Name: depName,
+			Purl: fmt.Sprintf("pkg:generic/%s", depName),
+		}
+		depComponents[depName] = component
+		bom.Components = append(bom.Components, component)
+	}
+
+	// Create dependencies relationships
+	if len(pkg.Depends) > 0 {
+		mainDep := &CycloneDXDependency{
+			Ref: mainComponent.Name,
+		}
+
+		for _, dep := range pkg.Depends {
+			depName := extractDepName(dep)
+			if depName != "" {
+				mainDep.Depends = append(mainDep.Depends, depName)
+			}
+		}
+
+		bom.Dependencies = append(bom.Dependencies, mainDep)
+	}
+
+	return bom
+}
+
+// generatePurl generates a Package URL (purl) for the given package.
+func generatePurl(pkg *pkgbuild.PKGBUILD) string {
+	// Basic purl format: pkg:type/namespace/name@version
+	// For generic packages: pkg:generic/name@version
+	return fmt.Sprintf("pkg:generic/%s@%s", pkg.PkgName, pkg.PkgVer)
+}
+
+// extractDepName extracts the package name from a dependency string.
+// Handles formats like "gcc", "gcc>=11.0", "python3 >=3.9", etc.
+func extractDepName(dep string) string {
+	fields := strings.Fields(dep)
+	if len(fields) == 0 {
+		return ""
+	}
+
+	// Remove version constraints
+	name := fields[0]
+	for _, op := range []string{">=", "<=", "==", "!=", ">", "<", "~"} {
+		if idx := strings.Index(name, op); idx != -1 {
+			name = name[:idx]
+			break
+		}
+	}
+
+	return strings.TrimSpace(name)
+}

--- a/pkg/sbom/integration_test.go
+++ b/pkg/sbom/integration_test.go
@@ -1,0 +1,272 @@
+package sbom_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/M0Rf30/yap/v2/pkg/pkgbuild"
+	"github.com/M0Rf30/yap/v2/pkg/sbom"
+)
+
+// TestSBOMIntegration tests the complete SBOM generation workflow.
+func TestSBOMIntegration(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a realistic package
+	pkg := &pkgbuild.PKGBUILD{
+		PkgName:     "myapp",
+		PkgVer:      "2.1.0",
+		PkgRel:      "3",
+		PkgDesc:     "A sample application for testing SBOM generation",
+		License:     []string{"MIT", "Apache-2.0"},
+		URL:         "https://github.com/example/myapp",
+		SourceURI:   []string{"https://github.com/example/myapp/archive/v2.1.0.tar.gz"},
+		Depends:     []string{"openssl>=1.1.0", "zlib", "libcurl"},
+		MakeDepends: []string{"gcc>=11", "cmake>=3.20", "git"},
+		Maintainer:  "Test User <test@example.com>",
+	}
+
+	// Test artifact path
+	artifactPath := filepath.Join(tmpDir, "myapp-2.1.0-3-x86_64.deb")
+
+	// Generate both formats
+	opts := sbom.Options{
+		Formats: []sbom.Format{sbom.FormatCycloneDX, sbom.FormatSPDX},
+	}
+
+	generatedFiles, err := sbom.Generate(pkg, artifactPath, opts)
+	require.NoError(t, err)
+	require.Len(t, generatedFiles, 2)
+
+	// Verify CycloneDX file
+	cdxPath := artifactPath + ".cdx.json"
+	assert.FileExists(t, cdxPath)
+
+	cdxData, err := os.ReadFile(cdxPath)
+	require.NoError(t, err)
+
+	var cdxBOM sbom.CycloneDXBOM
+
+	err = json.Unmarshal(cdxData, &cdxBOM)
+	require.NoError(t, err)
+
+	// Validate CycloneDX structure
+	assert.Equal(t, "CycloneDX", cdxBOM.BOMFormat)
+	assert.Equal(t, "1.5", cdxBOM.SpecVersion)
+	assert.NotNil(t, cdxBOM.Metadata)
+	assert.NotNil(t, cdxBOM.Metadata.Component)
+	assert.Equal(t, "myapp", cdxBOM.Metadata.Component.Name)
+	assert.Equal(t, "2.1.0", cdxBOM.Metadata.Component.Version)
+	assert.Equal(t, "A sample application for testing SBOM generation",
+		cdxBOM.Metadata.Component.Description)
+
+	// Verify licenses
+	assert.Len(t, cdxBOM.Metadata.Component.Licenses, 2)
+
+	licenseNames := make(map[string]bool)
+	for _, lic := range cdxBOM.Metadata.Component.Licenses {
+		licenseNames[lic.License.Name] = true
+	}
+
+	assert.True(t, licenseNames["MIT"])
+	assert.True(t, licenseNames["Apache-2.0"])
+
+	// Verify external references
+	assert.Len(t, cdxBOM.Metadata.Component.ExternalReferences, 1)
+	assert.Equal(t, "distribution",
+		cdxBOM.Metadata.Component.ExternalReferences[0].Type)
+	assert.Equal(t, "https://github.com/example/myapp/archive/v2.1.0.tar.gz",
+		cdxBOM.Metadata.Component.ExternalReferences[0].URL)
+
+	// Verify components (dependencies)
+	assert.NotEmpty(t, cdxBOM.Components)
+
+	componentNames := make(map[string]bool)
+	for _, comp := range cdxBOM.Components {
+		componentNames[comp.Name] = true
+	}
+
+	assert.True(t, componentNames["openssl"])
+	assert.True(t, componentNames["zlib"])
+	assert.True(t, componentNames["libcurl"])
+	assert.True(t, componentNames["gcc"])
+	assert.True(t, componentNames["cmake"])
+	assert.True(t, componentNames["git"])
+
+	// Verify SPDX file
+	spdxPath := artifactPath + ".spdx.json"
+	assert.FileExists(t, spdxPath)
+
+	spdxData, err := os.ReadFile(spdxPath)
+	require.NoError(t, err)
+
+	var spdxDoc sbom.SPDXDocument
+
+	err = json.Unmarshal(spdxData, &spdxDoc)
+	require.NoError(t, err)
+
+	// Validate SPDX structure
+	assert.Equal(t, "SPDX-2.3", spdxDoc.SPDXVersion)
+	assert.Equal(t, "CC0-1.0", spdxDoc.DataLicense)
+	assert.Equal(t, "SPDXRef-DOCUMENT", spdxDoc.SPDXID)
+	assert.NotEmpty(t, spdxDoc.DocumentNamespace)
+	assert.Contains(t, spdxDoc.DocumentNamespace, "myapp")
+	assert.Contains(t, spdxDoc.DocumentNamespace, "2.1.0")
+
+	// Verify creation info
+	assert.NotNil(t, spdxDoc.CreationInfo)
+	assert.NotEmpty(t, spdxDoc.CreationInfo.Created)
+	assert.Contains(t, spdxDoc.CreationInfo.Creators, "Tool: yap")
+
+	// Verify packages
+	assert.NotEmpty(t, spdxDoc.Packages)
+	mainPkg := spdxDoc.Packages[0]
+	assert.Equal(t, "SPDXRef-Package", mainPkg.SPDXID)
+	assert.Equal(t, "myapp", mainPkg.Name)
+	assert.Equal(t, "2.1.0", mainPkg.Version)
+	assert.False(t, mainPkg.FilesAnalyzed)
+
+	// Verify licenses
+	assert.Equal(t, "MIT OR Apache-2.0", mainPkg.LicenseConcluded)
+	assert.Equal(t, "MIT OR Apache-2.0", mainPkg.LicenseDeclared)
+
+	// Verify relationships
+	assert.NotEmpty(t, spdxDoc.Relationships)
+
+	hasDescribes := false
+	dependsOnCount := 0
+
+	for _, rel := range spdxDoc.Relationships {
+		if rel.RelationshipType == "DESCRIBES" {
+			hasDescribes = true
+		}
+
+		if rel.RelationshipType == "DEPENDS_ON" {
+			dependsOnCount++
+		}
+	}
+
+	assert.True(t, hasDescribes)
+	assert.Greater(t, dependsOnCount, 0)
+}
+
+// TestSBOMWithMinimalPackage tests SBOM generation with minimal package info.
+func TestSBOMWithMinimalPackage(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pkg := &pkgbuild.PKGBUILD{
+		PkgName: "minimal",
+		PkgVer:  "1.0",
+		PkgRel:  "1",
+	}
+
+	artifactPath := filepath.Join(tmpDir, "minimal-1.0-1-x86_64.rpm")
+
+	opts := sbom.Options{
+		Formats: []sbom.Format{sbom.FormatCycloneDX, sbom.FormatSPDX},
+	}
+
+	generatedFiles, err := sbom.Generate(pkg, artifactPath, opts)
+	require.NoError(t, err)
+	require.Len(t, generatedFiles, 2)
+
+	// Verify files exist
+	assert.FileExists(t, artifactPath+".cdx.json")
+	assert.FileExists(t, artifactPath+".spdx.json")
+
+	// Verify CycloneDX is valid JSON
+	cdxData, err := os.ReadFile(artifactPath + ".cdx.json")
+	require.NoError(t, err)
+
+	var cdxBOM sbom.CycloneDXBOM
+
+	err = json.Unmarshal(cdxData, &cdxBOM)
+	require.NoError(t, err)
+	assert.Equal(t, "minimal", cdxBOM.Metadata.Component.Name)
+
+	// Verify SPDX is valid JSON
+	spdxData, err := os.ReadFile(artifactPath + ".spdx.json")
+	require.NoError(t, err)
+
+	var spdxDoc sbom.SPDXDocument
+
+	err = json.Unmarshal(spdxData, &spdxDoc)
+	require.NoError(t, err)
+	assert.Equal(t, "SPDX-2.3", spdxDoc.SPDXVersion)
+}
+
+// TestSBOMFormatSelection tests different SBOM format selections.
+func TestSBOMFormatSelection(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pkg := &pkgbuild.PKGBUILD{
+		PkgName: "test",
+		PkgVer:  "1.0",
+		PkgRel:  "1",
+	}
+
+	tests := []struct {
+		name      string
+		formats   []sbom.Format
+		wantFiles int
+		wantCDX   bool
+		wantSPDX  bool
+	}{
+		{
+			name:      "CycloneDX only",
+			formats:   []sbom.Format{sbom.FormatCycloneDX},
+			wantFiles: 1,
+			wantCDX:   true,
+			wantSPDX:  false,
+		},
+		{
+			name:      "SPDX only",
+			formats:   []sbom.Format{sbom.FormatSPDX},
+			wantFiles: 1,
+			wantCDX:   false,
+			wantSPDX:  true,
+		},
+		{
+			name:      "Both formats",
+			formats:   []sbom.Format{sbom.FormatCycloneDX, sbom.FormatSPDX},
+			wantFiles: 2,
+			wantCDX:   true,
+			wantSPDX:  true,
+		},
+		{
+			name:      "No formats",
+			formats:   []sbom.Format{},
+			wantFiles: 0,
+			wantCDX:   false,
+			wantSPDX:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			artifactPath := filepath.Join(tmpDir, tt.name+"-1.0-1-x86_64.deb")
+
+			opts := sbom.Options{Formats: tt.formats}
+			generatedFiles, err := sbom.Generate(pkg, artifactPath, opts)
+			require.NoError(t, err)
+			assert.Len(t, generatedFiles, tt.wantFiles)
+
+			if tt.wantCDX {
+				assert.FileExists(t, artifactPath+".cdx.json")
+			} else {
+				assert.NoFileExists(t, artifactPath+".cdx.json")
+			}
+
+			if tt.wantSPDX {
+				assert.FileExists(t, artifactPath+".spdx.json")
+			} else {
+				assert.NoFileExists(t, artifactPath+".spdx.json")
+			}
+		})
+	}
+}

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -1,0 +1,111 @@
+// Package sbom provides Software Bill of Materials (SBOM) generation
+// for YAP packages in CycloneDX and SPDX formats.
+package sbom
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/M0Rf30/yap/v2/pkg/errors"
+	"github.com/M0Rf30/yap/v2/pkg/logger"
+	"github.com/M0Rf30/yap/v2/pkg/pkgbuild"
+)
+
+// Format is the SBOM output format.
+type Format string
+
+const (
+	// FormatCycloneDX represents CycloneDX 1.5 JSON format.
+	FormatCycloneDX Format = "cyclonedx"
+	// FormatSPDX represents SPDX 2.3 JSON format.
+	FormatSPDX Format = "spdx"
+)
+
+// Options controls SBOM generation.
+type Options struct {
+	// Formats is a list of SBOM formats to generate.
+	// Empty list means no SBOM generation.
+	Formats []Format
+}
+
+// Generate writes one SBOM sidecar per requested format next to artifactPath.
+// Returns the list of sidecar paths written, or an error if generation fails.
+// If SBOM generation is disabled (empty Formats), returns empty list and nil error.
+func Generate(pkg *pkgbuild.PKGBUILD, artifactPath string,
+	opts Options) ([]string, error) {
+	if len(opts.Formats) == 0 {
+		return []string{}, nil
+	}
+
+	var generatedFiles []string
+
+	for _, format := range opts.Formats {
+		var (
+			sbomPath string
+			sbomData any
+		)
+
+		switch format {
+		case FormatCycloneDX:
+			sbomPath = artifactPath + ".cdx.json"
+			sbomData = generateCycloneDX(pkg)
+		case FormatSPDX:
+			sbomPath = artifactPath + ".spdx.json"
+			sbomData = generateSPDX(pkg)
+		default:
+			logger.Warn("Unknown SBOM format",
+				"format", format)
+
+			continue
+		}
+
+		// Marshal to JSON
+		jsonData, err := json.MarshalIndent(sbomData, "", "  ")
+		if err != nil {
+			logger.Warn("Failed to marshal SBOM to JSON",
+				"format", format,
+				"artifact", filepath.Base(artifactPath),
+				"error", err)
+
+			continue
+		}
+
+		// Write to file
+		//nolint:gosec // SBOM sidecars are intentionally world-readable
+		if err := os.WriteFile(sbomPath, jsonData, 0o644); err != nil {
+			logger.Warn("Failed to write SBOM file",
+				"path", sbomPath,
+				"error", err)
+
+			continue
+		}
+
+		logger.Debug("Generated SBOM",
+			"format", format,
+			"path", sbomPath)
+
+		generatedFiles = append(generatedFiles, sbomPath)
+	}
+
+	return generatedFiles, nil
+}
+
+// ValidateOptions validates SBOM generation options.
+// Returns an error if the options are invalid.
+func ValidateOptions(opts Options) error {
+	for _, format := range opts.Formats {
+		switch format {
+		case FormatCycloneDX, FormatSPDX:
+			// Valid formats
+		default:
+			return errors.New(errors.ErrTypeConfiguration,
+				fmt.Sprintf("invalid SBOM format: %s", format)).
+				WithOperation("ValidateOptions").
+				WithContext("format", string(format))
+		}
+	}
+
+	return nil
+}

--- a/pkg/sbom/sbom_internal_test.go
+++ b/pkg/sbom/sbom_internal_test.go
@@ -1,0 +1,153 @@
+package sbom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/M0Rf30/yap/v2/pkg/pkgbuild"
+)
+
+func TestExtractDepName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"gcc", "gcc"},
+		{"gcc >=11", "gcc"},
+		{"gcc <=11", "gcc"},
+		{"gcc =11", "gcc"},
+		{"gcc >11", "gcc"},
+		{"gcc <11", "gcc"},
+		{"", ""},
+		{"  ", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := extractDepName(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGeneratePurl(t *testing.T) {
+	pkg := &pkgbuild.PKGBUILD{
+		PkgName: "testpkg",
+		PkgVer:  "1.0.0",
+	}
+
+	purl := generatePurl(pkg)
+	assert.Equal(t, "pkg:generic/testpkg@1.0.0", purl)
+}
+
+func TestGenerateDocumentNamespace(t *testing.T) {
+	pkg := &pkgbuild.PKGBUILD{
+		PkgName: "testpkg",
+		PkgVer:  "1.0.0",
+		PkgRel:  "1",
+	}
+
+	ns := generateDocumentNamespace(pkg)
+	assert.Equal(t, "https://yap.build/sbom/testpkg-1.0.0-1", ns)
+}
+
+func TestGenerateCycloneDX(t *testing.T) {
+	pkg := &pkgbuild.PKGBUILD{
+		PkgName:     "testpkg",
+		PkgVer:      "1.0.0",
+		PkgRel:      "1",
+		PkgDesc:     "Test package description",
+		License:     []string{"MIT", "Apache-2.0"},
+		SourceURI:   []string{"https://example.com/testpkg-1.0.0.tar.gz"},
+		Depends:     []string{"gcc", "make>=4.0"},
+		MakeDepends: []string{"git", "cmake"},
+	}
+
+	bom := generateCycloneDX(pkg)
+	require.NotNil(t, bom)
+
+	// Verify BOM structure
+	assert.Equal(t, "CycloneDX", bom.BOMFormat)
+	assert.Equal(t, "1.5", bom.SpecVersion)
+	assert.NotEmpty(t, bom.SerialNumber)
+
+	// Verify metadata component
+	require.NotNil(t, bom.Metadata)
+	require.NotNil(t, bom.Metadata.Component)
+	assert.Equal(t, "testpkg", bom.Metadata.Component.Name)
+	assert.Equal(t, "1.0.0", bom.Metadata.Component.Version)
+	assert.Equal(t, "Test package description", bom.Metadata.Component.Description)
+
+	// Verify licenses
+	assert.Len(t, bom.Metadata.Component.Licenses, 2)
+	assert.Equal(t, "MIT", bom.Metadata.Component.Licenses[0].License.Name)
+	assert.Equal(t, "Apache-2.0", bom.Metadata.Component.Licenses[1].License.Name)
+
+	// Verify external references
+	assert.Len(t, bom.Metadata.Component.ExternalReferences, 1)
+	assert.Equal(t, "distribution", bom.Metadata.Component.ExternalReferences[0].Type)
+	assert.Equal(t, "https://example.com/testpkg-1.0.0.tar.gz",
+		bom.Metadata.Component.ExternalReferences[0].URL)
+
+	// Verify components (dependencies)
+	assert.NotEmpty(t, bom.Components)
+
+	componentNames := make(map[string]bool)
+	for _, comp := range bom.Components {
+		componentNames[comp.Name] = true
+	}
+
+	assert.True(t, componentNames["gcc"])
+	assert.True(t, componentNames["make"])
+	assert.True(t, componentNames["git"])
+	assert.True(t, componentNames["cmake"])
+
+	// Verify dependencies relationships
+	assert.NotEmpty(t, bom.Dependencies)
+	assert.Equal(t, "testpkg", bom.Dependencies[0].Ref)
+	assert.Contains(t, bom.Dependencies[0].Depends, "gcc")
+	assert.Contains(t, bom.Dependencies[0].Depends, "make")
+}
+
+func TestGenerateSPDX(t *testing.T) {
+	pkg := &pkgbuild.PKGBUILD{
+		PkgName:     "testpkg",
+		PkgVer:      "1.0.0",
+		PkgRel:      "1",
+		PkgDesc:     "Test package description",
+		License:     []string{"MIT"},
+		SourceURI:   []string{"https://example.com/testpkg-1.0.0.tar.gz"},
+		URL:         "https://example.com",
+		Depends:     []string{"gcc"},
+		MakeDepends: []string{"git"},
+	}
+
+	doc := generateSPDX(pkg)
+	require.NotNil(t, doc)
+
+	// Verify document structure
+	assert.Equal(t, "SPDX-2.3", doc.SPDXVersion)
+	assert.Equal(t, "CC0-1.0", doc.DataLicense)
+	assert.Equal(t, "SPDXRef-DOCUMENT", doc.SPDXID)
+	assert.NotEmpty(t, doc.DocumentNamespace)
+
+	// Verify creation info
+	require.NotNil(t, doc.CreationInfo)
+	assert.NotEmpty(t, doc.CreationInfo.Created)
+	assert.Contains(t, doc.CreationInfo.Creators, "Tool: yap")
+
+	// Verify packages
+	assert.NotEmpty(t, doc.Packages)
+	mainPkg := doc.Packages[0]
+	assert.Equal(t, "SPDXRef-Package", mainPkg.SPDXID)
+	assert.Equal(t, "testpkg", mainPkg.Name)
+	assert.Equal(t, "1.0.0", mainPkg.Version)
+	assert.Equal(t, "Test package description", mainPkg.Description)
+	assert.False(t, mainPkg.FilesAnalyzed)
+
+	// Verify licenses
+	assert.Equal(t, "MIT", mainPkg.LicenseConcluded)
+	assert.Equal(t, "MIT", mainPkg.LicenseDeclared)
+}

--- a/pkg/sbom/sbom_test.go
+++ b/pkg/sbom/sbom_test.go
@@ -1,0 +1,124 @@
+package sbom_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/M0Rf30/yap/v2/pkg/pkgbuild"
+	"github.com/M0Rf30/yap/v2/pkg/sbom"
+)
+
+func TestGenerateToFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	artifactPath := filepath.Join(tmpDir, "testpkg-1.0.0-1-x86_64.deb")
+
+	pkg := &pkgbuild.PKGBUILD{
+		PkgName:     "testpkg",
+		PkgVer:      "1.0.0",
+		PkgRel:      "1",
+		PkgDesc:     "Test package",
+		License:     []string{"MIT"},
+		SourceURI:   []string{"https://example.com/testpkg-1.0.0.tar.gz"},
+		Depends:     []string{"gcc"},
+		MakeDepends: []string{"git"},
+	}
+
+	opts := sbom.Options{
+		Formats: []sbom.Format{sbom.FormatCycloneDX, sbom.FormatSPDX},
+	}
+
+	generatedFiles, err := sbom.Generate(pkg, artifactPath, opts)
+	require.NoError(t, err)
+	assert.Len(t, generatedFiles, 2)
+
+	// Verify CycloneDX file
+	cdxPath := artifactPath + ".cdx.json"
+	assert.FileExists(t, cdxPath)
+	cdxData, err := os.ReadFile(cdxPath)
+	require.NoError(t, err)
+
+	var cdxBOM sbom.CycloneDXBOM
+
+	err = json.Unmarshal(cdxData, &cdxBOM)
+	require.NoError(t, err)
+	assert.Equal(t, "CycloneDX", cdxBOM.BOMFormat)
+	assert.Equal(t, "1.5", cdxBOM.SpecVersion)
+
+	// Verify SPDX file
+	spdxPath := artifactPath + ".spdx.json"
+	assert.FileExists(t, spdxPath)
+	spdxData, err := os.ReadFile(spdxPath)
+	require.NoError(t, err)
+
+	var spdxDoc sbom.SPDXDocument
+
+	err = json.Unmarshal(spdxData, &spdxDoc)
+	require.NoError(t, err)
+	assert.Equal(t, "SPDX-2.3", spdxDoc.SPDXVersion)
+	assert.Equal(t, "CC0-1.0", spdxDoc.DataLicense)
+}
+
+func TestGenerateEmptyFormats(t *testing.T) {
+	pkg := &pkgbuild.PKGBUILD{
+		PkgName: "testpkg",
+		PkgVer:  "1.0.0",
+	}
+
+	opts := sbom.Options{
+		Formats: []sbom.Format{},
+	}
+
+	generatedFiles, err := sbom.Generate(pkg, "/tmp/artifact", opts)
+	require.NoError(t, err)
+	assert.Empty(t, generatedFiles)
+}
+
+func TestValidateOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    sbom.Options
+		wantErr bool
+	}{
+		{
+			name:    "valid cyclonedx",
+			opts:    sbom.Options{Formats: []sbom.Format{sbom.FormatCycloneDX}},
+			wantErr: false,
+		},
+		{
+			name:    "valid spdx",
+			opts:    sbom.Options{Formats: []sbom.Format{sbom.FormatSPDX}},
+			wantErr: false,
+		},
+		{
+			name:    "valid both",
+			opts:    sbom.Options{Formats: []sbom.Format{sbom.FormatCycloneDX, sbom.FormatSPDX}},
+			wantErr: false,
+		},
+		{
+			name:    "invalid format",
+			opts:    sbom.Options{Formats: []sbom.Format{"invalid"}},
+			wantErr: true,
+		},
+		{
+			name:    "empty formats",
+			opts:    sbom.Options{Formats: []sbom.Format{}},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := sbom.ValidateOptions(tt.opts)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -1,0 +1,197 @@
+package sbom
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/M0Rf30/yap/v2/pkg/pkgbuild"
+)
+
+// SPDXDocument represents an SPDX 2.3 document.
+type SPDXDocument struct {
+	SPDXVersion       string              `json:"spdxVersion"`
+	DataLicense       string              `json:"dataLicense"`
+	SPDXID            string              `json:"SPDXID"`
+	Name              string              `json:"name"`
+	DocumentNamespace string              `json:"documentNamespace"`
+	CreationInfo      *SPDXCreationInfo   `json:"creationInfo"`
+	Packages          []*SPDXPackage      `json:"packages,omitempty"`
+	Relationships     []*SPDXRelationship `json:"relationships,omitempty"`
+}
+
+// SPDXCreationInfo represents creation information in SPDX document.
+type SPDXCreationInfo struct {
+	Created            string   `json:"created"`
+	Creators           []string `json:"creators"`
+	LicenseListVersion string   `json:"licenseListVersion,omitempty"`
+}
+
+// SPDXPackage represents a package in SPDX document.
+type SPDXPackage struct {
+	SPDXID             string             `json:"SPDXID"`
+	Name               string             `json:"name"`
+	Version            string             `json:"versionInfo,omitempty"`
+	Description        string             `json:"description,omitempty"`
+	DownloadLocation   string             `json:"downloadLocation"`
+	FilesAnalyzed      bool               `json:"filesAnalyzed"`
+	LicenseConcluded   string             `json:"licenseConcluded,omitempty"`
+	LicenseDeclared    string             `json:"licenseDeclared,omitempty"`
+	CopyrightText      string             `json:"copyrightText,omitempty"`
+	ExternalReferences []*SPDXExternalRef `json:"externalReferences,omitempty"`
+}
+
+// SPDXExternalRef represents an external reference in SPDX package.
+type SPDXExternalRef struct {
+	ReferenceCategory string `json:"referenceCategory"`
+	ReferenceType     string `json:"referenceType"`
+	ReferenceLocator  string `json:"referenceLocator"`
+}
+
+// SPDXRelationship represents a relationship in SPDX document.
+type SPDXRelationship struct {
+	SpdxElementID      string `json:"spdxElementId"`
+	RelationshipType   string `json:"relationshipType"`
+	RelatedSpdxElement string `json:"relatedSpdxElement"`
+}
+
+const (
+	// spdxRefPackage is the SPDX identifier for the main package.
+	spdxRefPackage = "SPDXRef-Package"
+	// noAssertion is the SPDX value used when information is not asserted.
+	noAssertion = "NOASSERTION"
+)
+
+// generateSPDX generates an SPDX 2.3 SBOM for the given package.
+func generateSPDX(pkg *pkgbuild.PKGBUILD) *SPDXDocument {
+	doc := &SPDXDocument{
+		SPDXVersion:       "SPDX-2.3",
+		DataLicense:       "CC0-1.0",
+		SPDXID:            "SPDXRef-DOCUMENT",
+		Name:              fmt.Sprintf("YAP Package: %s", pkg.PkgName),
+		DocumentNamespace: generateDocumentNamespace(pkg),
+		CreationInfo: &SPDXCreationInfo{
+			Created:  time.Now().UTC().Format("2006-01-02T15:04:05Z"),
+			Creators: []string{"Tool: yap"},
+		},
+	}
+
+	// Create main package
+	mainPkg := &SPDXPackage{
+		SPDXID:           spdxRefPackage,
+		Name:             pkg.PkgName,
+		Version:          pkg.PkgVer,
+		Description:      pkg.PkgDesc,
+		DownloadLocation: getDownloadLocation(pkg),
+		FilesAnalyzed:    false,
+		CopyrightText:    noAssertion,
+	}
+
+	// Add licenses
+	if len(pkg.License) > 0 {
+		mainPkg.LicenseConcluded = strings.Join(pkg.License, " OR ")
+		mainPkg.LicenseDeclared = strings.Join(pkg.License, " OR ")
+	} else {
+		mainPkg.LicenseConcluded = noAssertion
+		mainPkg.LicenseDeclared = noAssertion
+	}
+
+	// Add external references for source URLs
+	for _, sourceURL := range pkg.SourceURI {
+		mainPkg.ExternalReferences = append(
+			mainPkg.ExternalReferences,
+			&SPDXExternalRef{
+				ReferenceCategory: "PACKAGE-MANAGER",
+				ReferenceType:     "source-url",
+				ReferenceLocator:  sourceURL,
+			},
+		)
+	}
+
+	doc.Packages = append(doc.Packages, mainPkg)
+
+	// Add runtime dependencies as packages
+	depPackages := make(map[string]*SPDXPackage)
+
+	for _, dep := range pkg.Depends {
+		depName := extractDepName(dep)
+		if depName == "" {
+			continue
+		}
+
+		depPkg := &SPDXPackage{
+			SPDXID:           fmt.Sprintf("SPDXRef-Dependency-%s", depName),
+			Name:             depName,
+			DownloadLocation: noAssertion,
+			FilesAnalyzed:    false,
+			CopyrightText:    noAssertion,
+			LicenseConcluded: noAssertion,
+			LicenseDeclared:  noAssertion,
+		}
+		depPackages[depName] = depPkg
+		doc.Packages = append(doc.Packages, depPkg)
+	}
+
+	// Add make dependencies as packages
+	for _, dep := range pkg.MakeDepends {
+		depName := extractDepName(dep)
+		if depName == "" || depPackages[depName] != nil {
+			continue
+		}
+
+		depPkg := &SPDXPackage{
+			SPDXID:           fmt.Sprintf("SPDXRef-Dependency-%s", depName),
+			Name:             depName,
+			DownloadLocation: noAssertion,
+			FilesAnalyzed:    false,
+			CopyrightText:    noAssertion,
+			LicenseConcluded: noAssertion,
+			LicenseDeclared:  noAssertion,
+		}
+		depPackages[depName] = depPkg
+		doc.Packages = append(doc.Packages, depPkg)
+	}
+
+	// Create relationships
+	// Main relationship: document describes package
+	doc.Relationships = append(doc.Relationships, &SPDXRelationship{
+		SpdxElementID:      "SPDXRef-DOCUMENT",
+		RelationshipType:   "DESCRIBES",
+		RelatedSpdxElement: spdxRefPackage,
+	})
+
+	// Dependency relationships
+	for _, dep := range pkg.Depends {
+		depName := extractDepName(dep)
+		if depName != "" {
+			doc.Relationships = append(doc.Relationships, &SPDXRelationship{
+				SpdxElementID:      spdxRefPackage,
+				RelationshipType:   "DEPENDS_ON",
+				RelatedSpdxElement: fmt.Sprintf("SPDXRef-Dependency-%s", depName),
+			})
+		}
+	}
+
+	return doc
+}
+
+// generateDocumentNamespace generates a unique document namespace for SPDX.
+func generateDocumentNamespace(pkg *pkgbuild.PKGBUILD) string {
+	// Format: https://yap.build/sbom/<pkg>-<ver>-<rel>
+	return fmt.Sprintf("https://yap.build/sbom/%s-%s-%s",
+		pkg.PkgName, pkg.PkgVer, pkg.PkgRel)
+}
+
+// getDownloadLocation returns the download location for the package.
+// Uses the first source URL if available, otherwise returns NOASSERTION.
+func getDownloadLocation(pkg *pkgbuild.PKGBUILD) string {
+	if len(pkg.SourceURI) > 0 {
+		return pkg.SourceURI[0]
+	}
+
+	if pkg.URL != "" {
+		return pkg.URL
+	}
+
+	return noAssertion
+}

--- a/pkg/signing/factory.go
+++ b/pkg/signing/factory.go
@@ -1,0 +1,41 @@
+package signing
+
+import (
+	"github.com/M0Rf30/yap/v2/pkg/errors"
+)
+
+// NewSigner constructs the appropriate concrete Signer for the format.
+//
+// For FormatAPK, returns an RSASigner (Phase 3 — PKCS#1 v1.5 SHA1).
+// For FormatDEB, FormatRPM, FormatPacman, returns a GPGSigner (Phase 4 — OpenPGP).
+//
+// If signing is disabled (cfg.Enabled == false), a NoopSigner is returned.
+func NewSigner(format Format, cfg Config) (Signer, error) {
+	// If signing is disabled, return a no-op signer
+	if !cfg.Enabled {
+		return NoopSigner{}, nil
+	}
+
+	// Validate that we have a key path
+	if cfg.KeyPath == "" {
+		return nil, errors.New(errors.ErrTypeConfiguration,
+			"signing enabled but no key path resolved").
+			WithOperation("NewSigner").
+			WithContext("format", string(format))
+	}
+
+	// Phase 3: APK RSA signing (PKCS#1 v1.5 SHA1)
+	if format == FormatAPK {
+		return NewRSASigner(cfg)
+	}
+
+	// Phase 4: DEB/RPM/Pacman GPG signing (OpenPGP)
+	if format == FormatDEB || format == FormatRPM || format == FormatPacman {
+		return NewGPGSigner(cfg, format)
+	}
+
+	return nil, errors.New(errors.ErrTypeConfiguration,
+		"unsupported format for signing").
+		WithOperation("NewSigner").
+		WithContext("format", string(format))
+}

--- a/pkg/signing/gpg.go
+++ b/pkg/signing/gpg.go
@@ -1,0 +1,256 @@
+package signing
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+
+	"github.com/M0Rf30/yap/v2/pkg/errors"
+	"github.com/M0Rf30/yap/v2/pkg/logger"
+)
+
+// GPGSigner produces detached OpenPGP signatures for DEB, RPM, and Pacman formats.
+// - DEB: writes <package>.deb.asc (ASCII-armored detached signature)
+// - RPM: provides signing function for rpmpack.SetPGPSigner (binary signature)
+// - Pacman: writes <package>.pkg.tar.zst.sig (binary detached signature)
+type GPGSigner struct {
+	cfg    Config
+	format Format
+	entity *openpgp.Entity
+}
+
+// NewGPGSigner loads the private key from cfg.KeyPath. The key must be an
+// ASCII-armored OpenPGP private key. If cfg.Passphrase is set, it is used
+// to decrypt the key.
+func NewGPGSigner(cfg Config, format Format) (*GPGSigner, error) {
+	// Read the key file
+	keyData, err := os.ReadFile(cfg.KeyPath)
+	if err != nil {
+		return nil, errors.Wrap(err, errors.ErrTypeFileSystem,
+			"failed to read GPG key file").
+			WithOperation("NewGPGSigner").
+			WithContext("key_path", cfg.KeyPath)
+	}
+
+	// Parse the armored key ring
+	keyRing, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(keyData))
+	if err != nil {
+		return nil, errors.Wrap(err, errors.ErrTypeConfiguration,
+			"failed to parse GPG key").
+			WithOperation("NewGPGSigner").
+			WithContext("key_path", cfg.KeyPath)
+	}
+
+	if len(keyRing) == 0 {
+		return nil, errors.New(errors.ErrTypeConfiguration,
+			"no keys found in GPG key file").
+			WithOperation("NewGPGSigner").
+			WithContext("key_path", cfg.KeyPath)
+	}
+
+	entity := keyRing[0]
+
+	// Decrypt the key if it's encrypted
+	if entity.PrivateKey != nil && entity.PrivateKey.Encrypted {
+		err := entity.PrivateKey.Decrypt([]byte(cfg.Passphrase))
+		if err != nil {
+			return nil, errors.Wrap(err, errors.ErrTypeConfiguration,
+				"failed to decrypt GPG key with passphrase").
+				WithOperation("NewGPGSigner").
+				WithContext("key_path", cfg.KeyPath)
+		}
+	}
+
+	// Verify we have a usable private key
+	if entity.PrivateKey == nil {
+		return nil, errors.New(errors.ErrTypeConfiguration,
+			"GPG key does not contain a private key").
+			WithOperation("NewGPGSigner").
+			WithContext("key_path", cfg.KeyPath)
+	}
+
+	logger.Debug("Loaded GPG private key for signing",
+		"key_path", cfg.KeyPath, "format", string(format),
+		"key_id", fmt.Sprintf("%X", entity.PrimaryKey.KeyId))
+
+	return &GPGSigner{
+		cfg:    cfg,
+		format: format,
+		entity: entity,
+	}, nil
+}
+
+// writeSignatureSidecar writes a signature sidecar file with the given extension.
+func (s *GPGSigner) writeSignatureSidecar(
+	artifactPath string,
+	signatureBuf *bytes.Buffer,
+	ext string,
+) error {
+	sigPath := artifactPath + ext
+	if err := os.WriteFile(sigPath, signatureBuf.Bytes(), 0o644); err != nil { //nolint:gosec // signature is public
+		return errors.Wrap(err, errors.ErrTypeFileSystem,
+			"failed to write signature file").
+			WithOperation("writeSignatureSidecar").
+			WithContext("signature_path", sigPath)
+	}
+
+	return nil
+}
+
+// Sign signs the artifact and writes a detached signature file.
+// Output convention by format:
+//
+//	FormatDEB    -> <artifactPath>.asc (ASCII-armored)
+//	FormatRPM    -> returns a signing function for rpmpack.SetPGPSigner
+//	FormatPacman -> <artifactPath>.sig (binary, NOT armored)
+func (s *GPGSigner) Sign(ctx context.Context, artifactPath string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// Read the artifact
+	artifactData, err := os.ReadFile(artifactPath) //nolint:gosec // path is the build output we just produced
+	if err != nil {
+		return errors.Wrap(err, errors.ErrTypeFileSystem,
+			"failed to read artifact for signing").
+			WithOperation("Sign").
+			WithContext("artifact_path", artifactPath)
+	}
+
+	// Create detached signature
+	signatureBuf := bytes.NewBuffer(nil)
+
+	switch s.format {
+	case FormatDEB:
+		// DEB: ASCII-armored detached signature
+		err = s.createArmoredDetachedSignature(artifactData, signatureBuf)
+		if err != nil {
+			return errors.Wrap(err, errors.ErrTypePackaging,
+				"failed to create DEB signature").
+				WithOperation("Sign").
+				WithContext("artifact_path", artifactPath)
+		}
+
+		if err := s.writeSignatureSidecar(artifactPath, signatureBuf, ".asc"); err != nil {
+			return err
+		}
+
+		logger.Info("DEB package signed successfully",
+			"artifact_path", artifactPath,
+			"signature_path", artifactPath+".asc")
+
+	case FormatPacman:
+		// Pacman: binary detached signature (NOT armored)
+		err = s.createBinaryDetachedSignature(artifactData, signatureBuf)
+		if err != nil {
+			return errors.Wrap(err, errors.ErrTypePackaging,
+				"failed to create Pacman signature").
+				WithOperation("Sign").
+				WithContext("artifact_path", artifactPath)
+		}
+
+		if err := s.writeSignatureSidecar(artifactPath, signatureBuf, ".sig"); err != nil {
+			return err
+		}
+
+		logger.Info("Pacman package signed successfully",
+			"artifact_path", artifactPath,
+			"signature_path", artifactPath+".sig")
+
+	case FormatRPM:
+		// RPM: binary detached signature (used by rpmpack.SetPGPSigner)
+		err = s.createBinaryDetachedSignature(artifactData, signatureBuf)
+		if err != nil {
+			return errors.Wrap(err, errors.ErrTypePackaging,
+				"failed to create RPM signature").
+				WithOperation("Sign").
+				WithContext("artifact_path", artifactPath)
+		}
+
+		if err := s.writeSignatureSidecar(artifactPath, signatureBuf, ".asc"); err != nil {
+			return err
+		}
+
+		logger.Info("RPM package signed successfully",
+			"artifact_path", artifactPath,
+			"signature_path", artifactPath+".asc")
+
+	default:
+		return errors.New(errors.ErrTypeConfiguration,
+			"unsupported format for GPG signing").
+			WithOperation("Sign").
+			WithContext("format", string(s.format))
+	}
+
+	return nil
+}
+
+// SignRPM returns a signing function suitable for rpmpack.SetPGPSigner.
+// This function takes the header+payload bytes and returns the signature bytes.
+func (s *GPGSigner) SignRPM(data []byte) ([]byte, error) {
+	signatureBuf := bytes.NewBuffer(nil)
+
+	err := s.createBinaryDetachedSignature(data, signatureBuf)
+	if err != nil {
+		return nil, errors.Wrap(err, errors.ErrTypePackaging,
+			"failed to sign RPM data").
+			WithOperation("SignRPM")
+	}
+
+	return signatureBuf.Bytes(), nil
+}
+
+// createArmoredDetachedSignature creates an ASCII-armored detached signature.
+func (s *GPGSigner) createArmoredDetachedSignature(
+	data []byte,
+	out io.Writer,
+) error {
+	// Create armor writer
+	armorWriter, err := armor.Encode(out, "PGP SIGNATURE", nil)
+	if err != nil {
+		return errors.Wrap(err, errors.ErrTypePackaging,
+			"failed to create armor writer").
+			WithOperation("createArmoredDetachedSignature")
+	}
+
+	defer func() {
+		_ = armorWriter.Close()
+	}()
+
+	// Create signature
+	err = openpgp.DetachSign(armorWriter, s.entity, bytes.NewReader(data), nil)
+	if err != nil {
+		return errors.Wrap(err, errors.ErrTypePackaging,
+			"failed to create detached signature").
+			WithOperation("createArmoredDetachedSignature")
+	}
+
+	return nil
+}
+
+// createBinaryDetachedSignature creates a binary detached signature.
+func (s *GPGSigner) createBinaryDetachedSignature(
+	data []byte,
+	out io.Writer,
+) error {
+	// Create signature
+	err := openpgp.DetachSign(out, s.entity, bytes.NewReader(data), nil)
+	if err != nil {
+		return errors.Wrap(err, errors.ErrTypePackaging,
+			"failed to create binary detached signature").
+			WithOperation("createBinaryDetachedSignature")
+	}
+
+	return nil
+}
+
+// GetSigningFunction returns a function suitable for rpmpack.SetPGPSigner.
+// This is used to integrate with rpmpack's built-in signing support.
+func (s *GPGSigner) GetSigningFunction() func([]byte) ([]byte, error) {
+	return s.SignRPM
+}

--- a/pkg/signing/gpg_internal_test.go
+++ b/pkg/signing/gpg_internal_test.go
@@ -1,0 +1,79 @@
+package signing
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	"github.com/stretchr/testify/require"
+)
+
+// generateTestGPGKey generates a test GPG key and returns both the entity
+// and its ASCII-armored bytes.
+func generateTestGPGKey(t *testing.T) (entity *openpgp.Entity, armored []byte) {
+	t.Helper()
+
+	var err error
+
+	entity, err = openpgp.NewEntity("Test User", "test", "test@example.com", nil)
+	if err != nil {
+		t.Fatalf("Failed to generate GPG key: %v", err)
+	}
+
+	// Encode to ASCII-armored format
+	keyBuf := bytes.NewBuffer(nil)
+
+	armorWriter, err := armor.Encode(keyBuf, openpgp.PublicKeyType, nil)
+	if err != nil {
+		t.Fatalf("Failed to create armor writer: %v", err)
+	}
+
+	err = entity.Serialize(armorWriter)
+	if err != nil {
+		t.Fatalf("Failed to serialize public key: %v", err)
+	}
+
+	_ = armorWriter.Close()
+
+	// Now encode the private key
+	privKeyBuf := bytes.NewBuffer(nil)
+
+	privArmorWriter, err := armor.Encode(privKeyBuf, openpgp.PrivateKeyType, nil)
+	if err != nil {
+		t.Fatalf("Failed to create private armor writer: %v", err)
+	}
+
+	err = entity.SerializePrivate(privArmorWriter, nil)
+	if err != nil {
+		t.Fatalf("Failed to serialize private key: %v", err)
+	}
+
+	_ = privArmorWriter.Close()
+
+	return entity, privKeyBuf.Bytes()
+}
+
+// TestNewGPGSignerValidKey tests loading a valid GPG private key.
+func TestNewGPGSignerValidKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "test.gpg")
+
+	_, keyPEM := generateTestGPGKey(t)
+
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	cfg := Config{
+		Enabled: true,
+		KeyPath: keyPath,
+	}
+
+	signer, err := NewGPGSigner(cfg, FormatDEB)
+	require.NotNil(t, signer)
+	require.NoError(t, err)
+	require.NotNil(t, signer.entity)
+}

--- a/pkg/signing/gpg_test.go
+++ b/pkg/signing/gpg_test.go
@@ -1,0 +1,344 @@
+package signing_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+
+	"github.com/M0Rf30/yap/v2/pkg/signing"
+)
+
+// generateTestGPGKey generates a test GPG key and returns its ASCII-armored
+// private key bytes. External tests only need the armored bytes; the internal
+// package test (gpg_internal_test.go) keeps the entity for direct verification.
+func generateTestGPGKey(t *testing.T) []byte {
+	t.Helper()
+
+	entity, err := openpgp.NewEntity("Test User", "test", "test@example.com", nil)
+	if err != nil {
+		t.Fatalf("Failed to generate GPG key: %v", err)
+	}
+
+	// Encode to ASCII-armored format
+	keyBuf := bytes.NewBuffer(nil)
+
+	armorWriter, err := armor.Encode(keyBuf, openpgp.PublicKeyType, nil)
+	if err != nil {
+		t.Fatalf("Failed to create armor writer: %v", err)
+	}
+
+	err = entity.Serialize(armorWriter)
+	if err != nil {
+		t.Fatalf("Failed to serialize public key: %v", err)
+	}
+
+	_ = armorWriter.Close()
+
+	// Now encode the private key
+	privKeyBuf := bytes.NewBuffer(nil)
+
+	privArmorWriter, err := armor.Encode(privKeyBuf, openpgp.PrivateKeyType, nil)
+	if err != nil {
+		t.Fatalf("Failed to create private armor writer: %v", err)
+	}
+
+	err = entity.SerializePrivate(privArmorWriter, nil)
+	if err != nil {
+		t.Fatalf("Failed to serialize private key: %v", err)
+	}
+
+	_ = privArmorWriter.Close()
+
+	return privKeyBuf.Bytes()
+}
+
+// TestNewGPGSignerInvalidKey tests that invalid key format is rejected.
+func TestNewGPGSignerInvalidKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "invalid.gpg")
+
+	if err := os.WriteFile(keyPath, []byte("not a valid GPG key"), 0o600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	cfg := signing.Config{
+		Enabled: true,
+		KeyPath: keyPath,
+	}
+
+	_, err := signing.NewGPGSigner(cfg, signing.FormatDEB)
+	if err == nil {
+		t.Errorf("NewGPGSigner() should reject invalid key")
+	}
+}
+
+// TestNewGPGSignerMissingFile tests that missing key file is handled.
+func TestNewGPGSignerMissingFile(t *testing.T) {
+	cfg := signing.Config{
+		Enabled: true,
+		KeyPath: "/nonexistent/path/key.gpg",
+	}
+
+	_, err := signing.NewGPGSigner(cfg, signing.FormatDEB)
+	if err == nil {
+		t.Errorf("NewGPGSigner() should reject missing file")
+	}
+}
+
+// TestGPGSignerSignDEB tests signing a DEB package.
+func TestGPGSignerSignDEB(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "test.gpg")
+	debPath := filepath.Join(tmpDir, "test.deb")
+
+	// Generate key and write to file
+	keyPEM := generateTestGPGKey(t)
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	// Create fake DEB file
+	debData := []byte("fake deb package data")
+	if err := os.WriteFile(debPath, debData, 0o644); err != nil {
+		t.Fatalf("Failed to write DEB file: %v", err)
+	}
+
+	// Create signer
+	cfg := signing.Config{
+		Enabled: true,
+		KeyPath: keyPath,
+	}
+
+	signer, err := signing.NewGPGSigner(cfg, signing.FormatDEB)
+	if err != nil {
+		t.Fatalf("NewGPGSigner() error = %v", err)
+	}
+
+	// Sign the DEB
+	ctx := context.Background()
+
+	err = signer.Sign(ctx, debPath)
+	if err != nil {
+		t.Fatalf("Sign() error = %v", err)
+	}
+
+	// Verify the signature file exists
+	sigPath := debPath + ".asc"
+	if _, err := os.Stat(sigPath); err != nil {
+		t.Fatalf("Signature file not created: %v", err)
+	}
+
+	// Verify the signature file is not empty
+	sigData, err := os.ReadFile(sigPath)
+	if err != nil {
+		t.Fatalf("Failed to read signature file: %v", err)
+	}
+
+	if len(sigData) == 0 {
+		t.Errorf("Signature file is empty")
+	}
+
+	// Verify it's ASCII-armored
+	if !bytes.Contains(sigData, []byte("-----BEGIN PGP SIGNATURE-----")) {
+		t.Errorf("Signature is not ASCII-armored")
+	}
+}
+
+// TestGPGSignerSignPacman tests signing a Pacman package.
+func TestGPGSignerSignPacman(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "test.gpg")
+	pkgPath := filepath.Join(tmpDir, "test.pkg.tar.zst")
+
+	// Generate key and write to file
+	keyPEM := generateTestGPGKey(t)
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	// Create fake Pacman package file
+	pkgData := []byte("fake pacman package data")
+	if err := os.WriteFile(pkgPath, pkgData, 0o644); err != nil {
+		t.Fatalf("Failed to write package file: %v", err)
+	}
+
+	// Create signer
+	cfg := signing.Config{
+		Enabled: true,
+		KeyPath: keyPath,
+	}
+
+	signer, err := signing.NewGPGSigner(cfg, signing.FormatPacman)
+	if err != nil {
+		t.Fatalf("NewGPGSigner() error = %v", err)
+	}
+
+	// Sign the package
+	ctx := context.Background()
+
+	err = signer.Sign(ctx, pkgPath)
+	if err != nil {
+		t.Fatalf("Sign() error = %v", err)
+	}
+
+	// Verify the signature file exists
+	sigPath := pkgPath + ".sig"
+	if _, err := os.Stat(sigPath); err != nil {
+		t.Fatalf("Signature file not created: %v", err)
+	}
+
+	// Verify the signature file is not empty
+	sigData, err := os.ReadFile(sigPath)
+	if err != nil {
+		t.Fatalf("Failed to read signature file: %v", err)
+	}
+
+	if len(sigData) == 0 {
+		t.Errorf("Signature file is empty")
+	}
+
+	// Verify it's binary (NOT ASCII-armored)
+	if bytes.Contains(sigData, []byte("-----BEGIN PGP SIGNATURE-----")) {
+		t.Errorf("Pacman signature should be binary, not ASCII-armored")
+	}
+}
+
+// TestGPGSignerSignRPM tests signing an RPM package.
+func TestGPGSignerSignRPM(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "test.gpg")
+	rpmPath := filepath.Join(tmpDir, "test.rpm")
+
+	// Generate key and write to file
+	keyPEM := generateTestGPGKey(t)
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	// Create fake RPM file
+	rpmData := []byte("fake rpm package data")
+	if err := os.WriteFile(rpmPath, rpmData, 0o644); err != nil {
+		t.Fatalf("Failed to write RPM file: %v", err)
+	}
+
+	// Create signer
+	cfg := signing.Config{
+		Enabled: true,
+		KeyPath: keyPath,
+	}
+
+	signer, err := signing.NewGPGSigner(cfg, signing.FormatRPM)
+	if err != nil {
+		t.Fatalf("NewGPGSigner() error = %v", err)
+	}
+
+	// Sign the RPM
+	ctx := context.Background()
+
+	err = signer.Sign(ctx, rpmPath)
+	if err != nil {
+		t.Fatalf("Sign() error = %v", err)
+	}
+
+	// Verify the signature file exists
+	sigPath := rpmPath + ".asc"
+	if _, err := os.Stat(sigPath); err != nil {
+		t.Fatalf("Signature file not created: %v", err)
+	}
+
+	// Verify the signature file is not empty
+	sigData, err := os.ReadFile(sigPath)
+	if err != nil {
+		t.Fatalf("Failed to read signature file: %v", err)
+	}
+
+	if len(sigData) == 0 {
+		t.Errorf("Signature file is empty")
+	}
+}
+
+// TestGPGSignerGetSigningFunction tests the RPM signing function.
+func TestGPGSignerGetSigningFunction(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "test.gpg")
+
+	// Generate key and write to file
+	keyPEM := generateTestGPGKey(t)
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	// Create signer
+	cfg := signing.Config{
+		Enabled: true,
+		KeyPath: keyPath,
+	}
+
+	signer, err := signing.NewGPGSigner(cfg, signing.FormatRPM)
+	if err != nil {
+		t.Fatalf("NewGPGSigner() error = %v", err)
+	}
+
+	// Get signing function
+	sigFunc := signer.GetSigningFunction()
+	if sigFunc == nil {
+		t.Errorf("GetSigningFunction() returned nil")
+	}
+
+	// Test the signing function
+	data := []byte("test data to sign")
+
+	signature, err := sigFunc(data)
+	if err != nil {
+		t.Fatalf("Signing function error = %v", err)
+	}
+
+	if len(signature) == 0 {
+		t.Errorf("Signature is empty")
+	}
+}
+
+// TestGPGSignerContextCancellation tests that context cancellation is respected.
+func TestGPGSignerContextCancellation(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "test.gpg")
+	debPath := filepath.Join(tmpDir, "test.deb")
+
+	// Generate key and write to file
+	keyPEM := generateTestGPGKey(t)
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	// Create fake DEB file
+	debData := []byte("fake deb package data")
+	if err := os.WriteFile(debPath, debData, 0o644); err != nil {
+		t.Fatalf("Failed to write DEB file: %v", err)
+	}
+
+	// Create signer
+	cfg := signing.Config{
+		Enabled: true,
+		KeyPath: keyPath,
+	}
+
+	signer, err := signing.NewGPGSigner(cfg, signing.FormatDEB)
+	if err != nil {
+		t.Fatalf("NewGPGSigner() error = %v", err)
+	}
+
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Try to sign with cancelled context
+	err = signer.Sign(ctx, debPath)
+	if err == nil {
+		t.Errorf("Sign() should fail with cancelled context")
+	}
+}

--- a/pkg/signing/resolve.go
+++ b/pkg/signing/resolve.go
@@ -1,0 +1,211 @@
+package signing
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/M0Rf30/yap/v2/pkg/errors"
+	"github.com/M0Rf30/yap/v2/pkg/logger"
+)
+
+// resolveAndValidateKeyPath resolves a key path to an absolute path and validates it exists.
+func resolveAndValidateKeyPath(rawPath, source, sourceLabel string) (string, error) {
+	absPath, err := filepath.Abs(rawPath)
+	if err != nil {
+		return "", errors.Wrap(err, errors.ErrTypeFileSystem,
+			"failed to resolve absolute path for key").
+			WithOperation("resolveAndValidateKeyPath").
+			WithContext("source", source).
+			WithContext("key_path", rawPath)
+	}
+
+	if _, err := os.Stat(absPath); err != nil {
+		return "", errors.Wrap(err, errors.ErrTypeFileSystem,
+			"key file not found").
+			WithOperation("resolveAndValidateKeyPath").
+			WithContext("source", source).
+			WithContext("key_path", absPath)
+	}
+
+	logger.Debug("Resolved signing key from "+sourceLabel,
+		source, sourceLabel, "key_path", absPath)
+
+	return absPath, nil
+}
+
+// Resolve produces a final Config for a given Format, applying the priority:
+// CLI flag > environment variable > project config > ~/.config/yap/keys/ default.
+//
+// For keys, the resolution order is:
+//  1. flagKey (CLI --sign-key)
+//  2. YAP_<FORMAT>_KEY env var (e.g., YAP_DEB_KEY)
+//  3. YAP_SIGN_KEY env var
+//  4. configKey (from yap.json signing.keyPath)
+//  5. Default search in ~/.config/yap/keys/
+//
+// For passphrases, the resolution order is:
+//  1. flagPass (CLI --sign-passphrase)
+//  2. YAP_<FORMAT>_PASSPHRASE env var (e.g., YAP_DEB_PASSPHRASE)
+//  3. YAP_SIGN_PASSPHRASE env var
+//  4. configPass (from yap.json signing.passphrase)
+//  5. Empty string (no passphrase)
+//
+// If signing is requested but no key can be resolved, an error is returned.
+// If no key is found, signing is disabled and passphrase is cleared.
+func Resolve(
+	format Format,
+	flagKey, flagPass, configKey, configPass string,
+) (Config, error) {
+	cfg := Config{}
+
+	// Resolve key path
+	keyPath, err := resolveKeyPath(format, flagKey, configKey)
+	if err != nil {
+		return cfg, err
+	}
+
+	cfg.KeyPath = keyPath
+	cfg.Enabled = keyPath != ""
+
+	// Only resolve passphrase if signing is enabled
+	if cfg.Enabled {
+		passphrase := resolvePassphrase(format, flagPass, configPass)
+		cfg.Passphrase = passphrase
+	}
+
+	return cfg, nil
+}
+
+// resolveKeyPath applies the priority order for key path resolution.
+func resolveKeyPath(format Format, flagKey, configKey string) (string, error) {
+	// Priority 1: CLI flag
+	if flagKey != "" {
+		return resolveAndValidateKeyPath(flagKey, "CLI flag", "CLI flag")
+	}
+
+	// Priority 2: Format-specific env var (e.g., YAP_DEB_KEY)
+	envKey := fmt.Sprintf("YAP_%s_KEY", strings.ToUpper(string(format)))
+	if envVal := os.Getenv(envKey); envVal != "" {
+		return resolveAndValidateKeyPath(envVal, envKey, "format-specific env var")
+	}
+
+	// Priority 3: Global env var (YAP_SIGN_KEY)
+	if envVal := os.Getenv("YAP_SIGN_KEY"); envVal != "" {
+		return resolveAndValidateKeyPath(envVal, "YAP_SIGN_KEY", "global env var")
+	}
+
+	// Priority 4: Project config
+	if configKey != "" {
+		return resolveAndValidateKeyPath(configKey, "yap.json", "project config")
+	}
+
+	// Priority 5: Default search in ~/.config/yap/keys/
+	defaultPath, found := findDefaultKey(format)
+	if found {
+		logger.Debug("Resolved signing key from default location",
+			"key_path", defaultPath)
+
+		return defaultPath, nil
+	}
+
+	// No key found; signing is disabled
+	return "", nil
+}
+
+// resolvePassphrase applies the priority order for passphrase resolution.
+func resolvePassphrase(format Format, flagPass, configPass string) string {
+	// Priority 1: CLI flag
+	if flagPass != "" {
+		logger.Debug("Resolved passphrase from CLI flag")
+		return flagPass
+	}
+
+	// Priority 2: Format-specific env var (e.g., YAP_DEB_PASSPHRASE)
+	envKey := fmt.Sprintf("YAP_%s_PASSPHRASE", strings.ToUpper(string(format)))
+	if envVal := os.Getenv(envKey); envVal != "" {
+		logger.Debug("Resolved passphrase from format-specific env var",
+			"env_var", envKey)
+
+		return envVal
+	}
+
+	// Priority 3: Global env var (YAP_SIGN_PASSPHRASE)
+	if envVal := os.Getenv("YAP_SIGN_PASSPHRASE"); envVal != "" {
+		logger.Debug("Resolved passphrase from global env var",
+			"env_var", "YAP_SIGN_PASSPHRASE")
+
+		return envVal
+	}
+
+	// Priority 4: Project config
+	if configPass != "" {
+		logger.Debug("Resolved passphrase from project config")
+		return configPass
+	}
+
+	// No passphrase found
+	return ""
+}
+
+// findDefaultKey searches ~/.config/yap/keys/ for a key matching the format.
+// It prefers format-specific files (e.g., apk.rsa, deb.gpg) and falls back
+// to default.rsa or default.gpg based on the algorithm.
+func findDefaultKey(format Format) (string, bool) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		logger.Debug("Failed to get home directory", "error", err)
+		return "", false
+	}
+
+	keysDir := filepath.Join(homeDir, ".config", "yap", "keys")
+
+	// Check if keys directory exists
+	if _, err := os.Stat(keysDir); err != nil {
+		logger.Debug("Default keys directory not found",
+			"path", keysDir)
+
+		return "", false
+	}
+
+	// Determine algorithm for this format
+	algo := algorithmForFormat(format)
+
+	// Try format-specific file first (e.g., apk.rsa, deb.gpg)
+	formatSpecificFile := filepath.Join(keysDir,
+		fmt.Sprintf("%s.%s", string(format), string(algo)))
+	if _, err := os.Stat(formatSpecificFile); err == nil {
+		logger.Debug("Found format-specific key file",
+			"path", formatSpecificFile)
+
+		return formatSpecificFile, true
+	}
+
+	// Fall back to default.<algo> (e.g., default.rsa, default.gpg)
+	defaultFile := filepath.Join(keysDir,
+		fmt.Sprintf("default.%s", string(algo)))
+	if _, err := os.Stat(defaultFile); err == nil {
+		logger.Debug("Found default key file",
+			"path", defaultFile)
+
+		return defaultFile, true
+	}
+
+	logger.Debug("No default key found for format",
+		"format", string(format), "keys_dir", keysDir)
+
+	return "", false
+}
+
+// algorithmForFormat returns the signing algorithm for a given format.
+func algorithmForFormat(format Format) Algorithm {
+	switch format {
+	case FormatAPK:
+		return AlgorithmRSA
+	case FormatDEB, FormatRPM, FormatPacman:
+		return AlgorithmGPG
+	default:
+		return AlgorithmGPG // Default to GPG for unknown formats
+	}
+}

--- a/pkg/signing/rsa.go
+++ b/pkg/signing/rsa.go
@@ -1,0 +1,336 @@
+package signing
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1" // nolint:gosec // APK protocol mandates SHA1
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/klauspost/compress/gzip"
+
+	"github.com/M0Rf30/yap/v2/pkg/errors"
+	"github.com/M0Rf30/yap/v2/pkg/logger"
+)
+
+// RSASigner signs APK packages with PKCS#1 v1.5 SHA1, matching Alpine abuild-sign.
+// The signature is computed over the control.tar.gz bytes and prepended as a
+// third gzip stream in the final APK file.
+type RSASigner struct {
+	cfg Config
+	key *rsa.PrivateKey
+}
+
+// NewRSASigner loads the private key from cfg.KeyPath. The key must be a
+// PEM-encoded RSA private key (PKCS#1 or PKCS#8 unencrypted).
+//
+// Encrypted PEM blocks (RFC 1423) are not supported because the underlying
+// stdlib helpers (x509.IsEncryptedPEMBlock, x509.DecryptPEMBlock) are
+// deprecated and the format is cryptographically broken. Users with
+// password-protected keys should re-encode them as unencrypted PEM
+// (e.g. via openssl rsa) or use PKCS#8 without password.
+func NewRSASigner(cfg Config) (*RSASigner, error) {
+	//nolint:gosec // key path comes from trusted yap config / CLI flag
+	keyData, err := os.ReadFile(cfg.KeyPath)
+	if err != nil {
+		return nil, errors.Wrap(err, errors.ErrTypeFileSystem,
+			"failed to read key file").
+			WithOperation("NewRSASigner").
+			WithContext("key_path", cfg.KeyPath)
+	}
+
+	key, err := parseRSAPrivateKey(keyData, cfg.KeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debug("Loaded RSA private key for APK signing",
+		"key_path", cfg.KeyPath, "key_size", key.N.BitLen())
+
+	return &RSASigner{
+		cfg: cfg,
+		key: key,
+	}, nil
+}
+
+// parseRSAPrivateKey decodes a PEM-encoded RSA private key. It accepts both
+// PKCS#1 ("RSA PRIVATE KEY") and PKCS#8 ("PRIVATE KEY") encodings.
+func parseRSAPrivateKey(keyData []byte, keyPath string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(keyData)
+	if block == nil {
+		return nil, errors.New(errors.ErrTypeConfiguration,
+			"invalid PEM format in key file").
+			WithOperation("parseRSAPrivateKey").
+			WithContext("key_path", keyPath)
+	}
+
+	if pkcs1Key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return pkcs1Key, nil
+	}
+
+	pkcs8Key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, errors.Wrap(err, errors.ErrTypeConfiguration,
+			"failed to parse private key (tried PKCS#1 and PKCS#8)").
+			WithOperation("parseRSAPrivateKey").
+			WithContext("key_path", keyPath)
+	}
+
+	rsaKey, ok := pkcs8Key.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New(errors.ErrTypeConfiguration,
+			"key is not an RSA private key").
+			WithOperation("parseRSAPrivateKey").
+			WithContext("key_path", keyPath)
+	}
+
+	return rsaKey, nil
+}
+
+// Sign reads the APK at artifactPath, computes the RSA signature over the
+// control.tar.gz stream, and rewrites the APK with the signature stream
+// prepended.
+//
+// The final APK structure is:
+//  1. signature.tar.gz — contains .SIGN.RSA.<keyname>.rsa.pub with signature bytes
+//  2. control.tar.gz — unchanged from original
+//  3. data.tar.gz — unchanged from original
+//
+// The signature is computed as PKCS#1 v1.5 SHA1(control.tar.gz bytes).
+func (s *RSASigner) Sign(ctx context.Context, artifactPath string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// Read the entire APK file
+	//nolint:gosec // artifactPath is the build output we just produced
+	apkData, err := os.ReadFile(artifactPath)
+	if err != nil {
+		return errors.Wrap(err, errors.ErrTypeFileSystem,
+			"failed to read APK file").
+			WithOperation("Sign").
+			WithContext("artifact_path", artifactPath)
+	}
+
+	// Find where the first gzip stream (control.tar.gz) ends
+	dataStart, err := extractFirstGzipStream(apkData)
+	if err != nil {
+		return errors.Wrap(err, errors.ErrTypePackaging,
+			"failed to extract control.tar.gz from APK").
+			WithOperation("Sign").
+			WithContext("artifact_path", artifactPath)
+	}
+
+	// The original control.tar.gz is the bytes from 0 to dataStart
+	controlTarGzCompressed := apkData[:dataStart]
+
+	// Compute SHA1 signature over control.tar.gz bytes (the compressed bytes)
+	// nolint:gosec // SHA1 required by APK format
+	hash := sha1.Sum(controlTarGzCompressed)
+
+	signature, err := rsa.SignPKCS1v15(rand.Reader, s.key, crypto.SHA1, hash[:])
+	if err != nil {
+		return errors.Wrap(err, errors.ErrTypePackaging,
+			"failed to sign control.tar.gz").
+			WithOperation("Sign").
+			WithContext("artifact_path", artifactPath)
+	}
+
+	logger.Debug("Computed APK signature",
+		"artifact_path", artifactPath,
+		"signature_size", len(signature),
+		"key_name", s.cfg.KeyName)
+
+	// Create signature tar stream
+	signatureTarGz, err := s.createSignatureTar(signature)
+	if err != nil {
+		return errors.Wrap(err, errors.ErrTypePackaging,
+			"failed to create signature tar").
+			WithOperation("Sign").
+			WithContext("artifact_path", artifactPath)
+	}
+
+	// Write the signed APK: signature.tar.gz + control.tar.gz + data.tar.gz
+	signedAPK := bytes.NewBuffer(nil)
+
+	if _, err := signedAPK.Write(signatureTarGz); err != nil {
+		return errors.Wrap(err, errors.ErrTypeFileSystem,
+			"failed to write signature to APK").
+			WithOperation("Sign").
+			WithContext("artifact_path", artifactPath)
+	}
+
+	if _, err := signedAPK.Write(controlTarGzCompressed); err != nil {
+		return errors.Wrap(err, errors.ErrTypeFileSystem,
+			"failed to write control to APK").
+			WithOperation("Sign").
+			WithContext("artifact_path", artifactPath)
+	}
+
+	if _, err := signedAPK.Write(apkData[dataStart:]); err != nil {
+		return errors.Wrap(err, errors.ErrTypeFileSystem,
+			"failed to write data to APK").
+			WithOperation("Sign").
+			WithContext("artifact_path", artifactPath)
+	}
+
+	// Write to temporary file first, then rename (atomic)
+	tmpPath := artifactPath + ".tmp"
+	//nolint:gosec // APK files are intentionally world-readable, matching abuild output
+	if err := os.WriteFile(tmpPath, signedAPK.Bytes(), 0o644); err != nil {
+		return errors.Wrap(err, errors.ErrTypeFileSystem,
+			"failed to write signed APK").
+			WithOperation("Sign").
+			WithContext("artifact_path", tmpPath)
+	}
+
+	// Atomic rename
+	if err := os.Rename(tmpPath, artifactPath); err != nil {
+		_ = os.Remove(tmpPath) // Best effort cleanup
+
+		return errors.Wrap(err, errors.ErrTypeFileSystem,
+			"failed to replace APK with signed version").
+			WithOperation("Sign").
+			WithContext("artifact_path", artifactPath)
+	}
+
+	logger.Info("APK package signed successfully",
+		"artifact_path", artifactPath,
+		"key_name", s.cfg.KeyName)
+
+	return nil
+}
+
+// createSignatureTar creates a gzip-compressed tar archive containing a single
+// entry: .SIGN.RSA.<keyname>.rsa.pub with the signature bytes as contents.
+func (s *RSASigner) createSignatureTar(signature []byte) ([]byte, error) {
+	// Determine key name
+	keyName := s.cfg.KeyName
+	if keyName == "" {
+		// Default: use basename of key file without extension
+		keyName = filepath.Base(s.cfg.KeyPath)
+		if idx := len(keyName) - len(filepath.Ext(keyName)); idx > 0 {
+			keyName = keyName[:idx]
+		}
+
+		// Fallback if no extension
+		if keyName == "" {
+			keyName = "yap"
+		}
+
+		logger.Debug("Using default key name for APK signature",
+			"key_name", keyName)
+	}
+
+	// Create tar entry name
+	entryName := fmt.Sprintf(".SIGN.RSA.%s.rsa.pub", keyName)
+
+	// Create tar archive in memory
+	tarBuf := bytes.NewBuffer(nil)
+	tw := tar.NewWriter(tarBuf)
+
+	// Create tar header for signature entry
+	hdr := &tar.Header{
+		Name:     entryName,
+		Size:     int64(len(signature)),
+		Mode:     0o644,
+		ModTime:  time.Unix(0, 0),
+		Uid:      0,
+		Gid:      0,
+		Uname:    "root",
+		Gname:    "root",
+		Typeflag: tar.TypeReg,
+		Format:   tar.FormatPAX,
+	}
+
+	// Add PAX records for reproducibility
+	hdr.PAXRecords = map[string]string{
+		"mtime": "0",
+		"atime": "0",
+		"ctime": "0",
+	}
+
+	// Write header
+	if err := tw.WriteHeader(hdr); err != nil {
+		return nil, errors.Wrap(err, errors.ErrTypePackaging,
+			"failed to write signature tar header").
+			WithOperation("createSignatureTar").
+			WithContext("entry_name", entryName)
+	}
+
+	// Write signature bytes
+	if _, err := tw.Write(signature); err != nil {
+		return nil, errors.Wrap(err, errors.ErrTypePackaging,
+			"failed to write signature to tar").
+			WithOperation("createSignatureTar").
+			WithContext("entry_name", entryName)
+	}
+
+	// Close tar writer
+	if err := tw.Close(); err != nil {
+		return nil, errors.Wrap(err, errors.ErrTypePackaging,
+			"failed to close tar writer").
+			WithOperation("createSignatureTar")
+	}
+
+	// Gzip the tar
+	gzBuf := bytes.NewBuffer(nil)
+	gz := gzip.NewWriter(gzBuf)
+	gz.ModTime = time.Unix(0, 0)
+
+	if _, err := gz.Write(tarBuf.Bytes()); err != nil {
+		return nil, errors.Wrap(err, errors.ErrTypePackaging,
+			"failed to gzip signature tar").
+			WithOperation("createSignatureTar")
+	}
+
+	if err := gz.Close(); err != nil {
+		return nil, errors.Wrap(err, errors.ErrTypePackaging,
+			"failed to close gzip writer").
+			WithOperation("createSignatureTar")
+	}
+
+	return gzBuf.Bytes(), nil
+}
+
+// extractFirstGzipStream returns the byte offset where the second concatenated
+// gzip stream begins by decompressing the first stream and tracking how many
+// bytes were consumed from the underlying reader.
+func extractFirstGzipStream(data []byte) (offset int, err error) {
+	reader := bytes.NewReader(data)
+	initialLen := reader.Len()
+
+	gz, err := gzip.NewReader(reader)
+	if err != nil {
+		return 0, errors.Wrap(err, errors.ErrTypePackaging,
+			"failed to create gzip reader").
+			WithOperation("extractFirstGzipStream")
+	}
+
+	if _, err = io.Copy(io.Discard, gz); err != nil {
+		_ = gz.Close()
+
+		return 0, errors.Wrap(err, errors.ErrTypePackaging,
+			"failed to decompress gzip stream").
+			WithOperation("extractFirstGzipStream")
+	}
+
+	if closeErr := gz.Close(); closeErr != nil {
+		return 0, errors.Wrap(closeErr, errors.ErrTypePackaging,
+			"failed to close gzip reader").
+			WithOperation("extractFirstGzipStream")
+	}
+
+	offset = initialLen - reader.Len()
+
+	return offset, nil
+}

--- a/pkg/signing/rsa_internal_test.go
+++ b/pkg/signing/rsa_internal_test.go
@@ -1,0 +1,240 @@
+package signing
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1" // nolint:gosec // APK protocol mandates SHA1
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// generateTestRSAKey generates a test RSA private key and returns both the
+// key and its PEM-encoded bytes.
+func generateTestRSAKey(t *testing.T) (key *rsa.PrivateKey, pemData []byte) {
+	t.Helper()
+
+	var err error
+
+	key, err = rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate RSA key: %v", err)
+	}
+
+	// Encode to PEM
+	privBytes := x509.MarshalPKCS1PrivateKey(key)
+	pemData = pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: privBytes,
+	})
+
+	return key, pemData
+}
+
+// createFakeAPK creates a fake APK file with two gzip streams (control + data).
+func createFakeAPK(t *testing.T) (apkBytes, controlData, dataData []byte) {
+	t.Helper()
+	// Create control.tar.gz
+	controlBuf := bytes.NewBuffer(nil)
+	gzControl := gzip.NewWriter(controlBuf)
+	twControl := tar.NewWriter(gzControl)
+
+	controlContent := []byte("control file content")
+	hdr := &tar.Header{
+		Name:    ".PKGINFO",
+		Size:    int64(len(controlContent)),
+		Mode:    0o644,
+		ModTime: time.Unix(0, 0),
+	}
+
+	if err := twControl.WriteHeader(hdr); err != nil {
+		t.Fatalf("Failed to write control header: %v", err)
+	}
+
+	if _, err := twControl.Write(controlContent); err != nil {
+		t.Fatalf("Failed to write control data: %v", err)
+	}
+
+	if err := twControl.Close(); err != nil {
+		t.Fatalf("Failed to close control tar: %v", err)
+	}
+
+	if err := gzControl.Close(); err != nil {
+		t.Fatalf("Failed to close control gzip: %v", err)
+	}
+
+	controlTarGz := controlBuf.Bytes()
+
+	// Create data.tar.gz
+	dataBuf := bytes.NewBuffer(nil)
+	gzData := gzip.NewWriter(dataBuf)
+	twData := tar.NewWriter(gzData)
+
+	dataContent := []byte("data file content")
+	dataHdr := &tar.Header{
+		Name:    "usr/bin/myapp",
+		Size:    int64(len(dataContent)),
+		Mode:    0o755,
+		ModTime: time.Unix(0, 0),
+	}
+
+	if err := twData.WriteHeader(dataHdr); err != nil {
+		t.Fatalf("Failed to write data header: %v", err)
+	}
+
+	if _, err := twData.Write(dataContent); err != nil {
+		t.Fatalf("Failed to write data content: %v", err)
+	}
+
+	if err := twData.Close(); err != nil {
+		t.Fatalf("Failed to close data tar: %v", err)
+	}
+
+	if err := gzData.Close(); err != nil {
+		t.Fatalf("Failed to close data gzip: %v", err)
+	}
+
+	dataTarGz := dataBuf.Bytes()
+
+	// Concatenate: control + data
+	apk := bytes.NewBuffer(nil)
+	apk.Write(controlTarGz)
+	apk.Write(dataTarGz)
+
+	return apk.Bytes(), controlTarGz, dataTarGz
+}
+
+// extractSignatureFromAPK extracts the signature bytes from the first tar entry.
+func extractSignatureFromAPK(t *testing.T, apkData []byte) ([]byte, error) {
+	t.Helper()
+
+	reader := bytes.NewReader(apkData)
+
+	gz, err := gzip.NewReader(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		_ = gz.Close()
+	}()
+
+	tr := tar.NewReader(gz)
+
+	_, err = tr.Next()
+	if err != nil {
+		return nil, err
+	}
+
+	signature, err := io.ReadAll(tr)
+	if err != nil {
+		return nil, err
+	}
+
+	return signature, nil
+}
+
+// TestNewRSASignerValidKey tests loading a valid RSA private key.
+func TestNewRSASignerValidKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "test.key")
+
+	_, keyPEM := generateTestRSAKey(t)
+
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	cfg := Config{
+		Enabled: true,
+		KeyPath: keyPath,
+		KeyName: "testkey",
+	}
+
+	signer, err := NewRSASigner(cfg)
+	require.NotNil(t, signer)
+	require.NoError(t, err)
+	require.NotNil(t, signer.key)
+}
+
+// TestRSASignerSignatureValidation tests that the signature is valid.
+// This test is in the internal package because it accesses extractFirstGzipStream.
+func TestRSASignerSignatureValidation(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "test.key")
+	apkPath := filepath.Join(tmpDir, "test.apk")
+
+	// Generate key
+	privKey, keyPEM := generateTestRSAKey(t)
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	// Create fake APK
+	apkData, _, _ := createFakeAPK(t)
+	if err := os.WriteFile(apkPath, apkData, 0o644); err != nil {
+		t.Fatalf("Failed to write APK file: %v", err)
+	}
+
+	// Find where the first gzip stream (control.tar.gz) ends
+	dataStart, err := extractFirstGzipStream(apkData)
+	if err != nil {
+		t.Fatalf("Failed to extract first gzip stream: %v", err)
+	}
+
+	controlTarGzCompressed := apkData[:dataStart]
+
+	// Sign the APK
+	cfg := Config{
+		Enabled: true,
+		KeyPath: keyPath,
+		KeyName: "testkey",
+	}
+
+	signer, err := NewRSASigner(cfg)
+	if err != nil {
+		t.Fatalf("NewRSASigner() error = %v", err)
+	}
+
+	ctx := context.Background()
+
+	err = signer.Sign(ctx, apkPath)
+	if err != nil {
+		t.Fatalf("Sign() error = %v", err)
+	}
+
+	// Read signed APK and extract signature
+	signedData, err := os.ReadFile(apkPath)
+	if err != nil {
+		t.Fatalf("Failed to read signed APK: %v", err)
+	}
+
+	// Extract signature from first gzip stream
+	signature, err := extractSignatureFromAPK(t, signedData)
+	if err != nil {
+		t.Fatalf("Failed to extract signature: %v", err)
+	}
+
+	// Verify signature against control.tar.gz (the compressed bytes)
+	// nolint:gosec // SHA1 required by APK format
+	hash := sha1.Sum(controlTarGzCompressed)
+
+	t.Logf("Control tar.gz size: %d, signature size: %d", len(controlTarGzCompressed), len(signature))
+
+	err = rsa.VerifyPKCS1v15(&privKey.PublicKey, crypto.SHA1, hash[:], signature)
+	if err != nil {
+		t.Errorf("Signature verification failed: %v", err)
+		t.Logf("Hash: %x", hash[:])
+	}
+}

--- a/pkg/signing/rsa_test.go
+++ b/pkg/signing/rsa_test.go
@@ -1,0 +1,283 @@
+package signing_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/M0Rf30/yap/v2/pkg/signing"
+)
+
+// createFakeAPK creates a fake APK file with two gzip streams (control + data)
+// and returns the concatenated bytes. The internal-package test uses its own
+// helper that exposes the individual streams.
+func createFakeAPK(t *testing.T) []byte {
+	t.Helper()
+	// Create control.tar.gz
+	controlBuf := bytes.NewBuffer(nil)
+	gzControl := gzip.NewWriter(controlBuf)
+	twControl := tar.NewWriter(gzControl)
+
+	controlContent := []byte("control file content")
+	hdr := &tar.Header{
+		Name:    ".PKGINFO",
+		Size:    int64(len(controlContent)),
+		Mode:    0o644,
+		ModTime: time.Unix(0, 0),
+	}
+
+	if err := twControl.WriteHeader(hdr); err != nil {
+		t.Fatalf("Failed to write control header: %v", err)
+	}
+
+	if _, err := twControl.Write(controlContent); err != nil {
+		t.Fatalf("Failed to write control data: %v", err)
+	}
+
+	if err := twControl.Close(); err != nil {
+		t.Fatalf("Failed to close control tar: %v", err)
+	}
+
+	if err := gzControl.Close(); err != nil {
+		t.Fatalf("Failed to close control gzip: %v", err)
+	}
+
+	controlTarGz := controlBuf.Bytes()
+
+	// Create data.tar.gz
+	dataBuf := bytes.NewBuffer(nil)
+	gzData := gzip.NewWriter(dataBuf)
+	twData := tar.NewWriter(gzData)
+
+	dataContent := []byte("data file content")
+	dataHdr := &tar.Header{
+		Name:    "usr/bin/myapp",
+		Size:    int64(len(dataContent)),
+		Mode:    0o755,
+		ModTime: time.Unix(0, 0),
+	}
+
+	if err := twData.WriteHeader(dataHdr); err != nil {
+		t.Fatalf("Failed to write data header: %v", err)
+	}
+
+	if _, err := twData.Write(dataContent); err != nil {
+		t.Fatalf("Failed to write data content: %v", err)
+	}
+
+	if err := twData.Close(); err != nil {
+		t.Fatalf("Failed to close data tar: %v", err)
+	}
+
+	if err := gzData.Close(); err != nil {
+		t.Fatalf("Failed to close data gzip: %v", err)
+	}
+
+	dataTarGz := dataBuf.Bytes()
+
+	// Concatenate: control + data
+	apk := bytes.NewBuffer(nil)
+	apk.Write(controlTarGz)
+	apk.Write(dataTarGz)
+
+	return apk.Bytes()
+}
+
+// generateTestRSAKey generates a test RSA private key and returns its
+// PEM-encoded bytes. The internal-package test uses its own helper that also
+// returns the live *rsa.PrivateKey for direct signature verification.
+func generateTestRSAKey(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate RSA key: %v", err)
+	}
+
+	privBytes := x509.MarshalPKCS1PrivateKey(key)
+
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: privBytes,
+	})
+}
+
+// TestNewRSASignerInvalidPEM tests that invalid PEM format is rejected.
+func TestNewRSASignerInvalidPEM(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "invalid.key")
+
+	if err := os.WriteFile(keyPath, []byte("not a valid PEM"), 0o600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	cfg := signing.Config{
+		Enabled: true,
+		KeyPath: keyPath,
+	}
+
+	_, err := signing.NewRSASigner(cfg)
+	if err == nil {
+		t.Errorf("NewRSASigner() should reject invalid PEM")
+	}
+}
+
+// TestNewRSASignerMissingFile tests that missing key file is handled.
+func TestNewRSASignerMissingFile(t *testing.T) {
+	cfg := signing.Config{
+		Enabled: true,
+		KeyPath: "/nonexistent/path/key.pem",
+	}
+
+	_, err := signing.NewRSASigner(cfg)
+	if err == nil {
+		t.Errorf("NewRSASigner() should reject missing file")
+	}
+}
+
+// TestRSASignerSign tests signing a fake APK.
+func TestRSASignerSign(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "test.key")
+	apkPath := filepath.Join(tmpDir, "test.apk")
+
+	// Generate key and write to file
+	keyPEM := generateTestRSAKey(t)
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	// Create fake APK
+	apkData := createFakeAPK(t)
+	if err := os.WriteFile(apkPath, apkData, 0o644); err != nil {
+		t.Fatalf("Failed to write APK file: %v", err)
+	}
+
+	// Create signer
+	cfg := signing.Config{
+		Enabled: true,
+		KeyPath: keyPath,
+		KeyName: "testkey",
+	}
+
+	signer, err := signing.NewRSASigner(cfg)
+	if err != nil {
+		t.Fatalf("NewRSASigner() error = %v", err)
+	}
+
+	// Sign the APK
+	ctx := context.Background()
+
+	err = signer.Sign(ctx, apkPath)
+	if err != nil {
+		t.Fatalf("Sign() error = %v", err)
+	}
+
+	// Verify the signed APK exists and is larger
+	signedData, err := os.ReadFile(apkPath)
+	if err != nil {
+		t.Fatalf("Failed to read signed APK: %v", err)
+	}
+
+	if len(signedData) <= len(apkData) {
+		t.Errorf("Signed APK should be larger than original, original=%d, signed=%d",
+			len(apkData), len(signedData))
+	}
+
+	// Verify the signature entry exists in the first tar entry
+	entryName, err := extractSignatureEntryName(t, signedData)
+	if err != nil {
+		t.Fatalf("Failed to extract entry name: %v", err)
+	}
+
+	if entryName != ".SIGN.RSA.testkey.rsa.pub" {
+		t.Errorf("Expected entry name '.SIGN.RSA.testkey.rsa.pub', got %q", entryName)
+	}
+}
+
+// TestRSASignerDefaultKeyName tests that default key name is derived from file.
+func TestRSASignerDefaultKeyName(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "mykey.pem")
+	apkPath := filepath.Join(tmpDir, "test.apk")
+
+	// Generate key
+	keyPEM := generateTestRSAKey(t)
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	// Create fake APK
+	apkData := createFakeAPK(t)
+	if err := os.WriteFile(apkPath, apkData, 0o644); err != nil {
+		t.Fatalf("Failed to write APK file: %v", err)
+	}
+
+	// Create signer WITHOUT explicit key name
+	cfg := signing.Config{
+		Enabled: true,
+		KeyPath: keyPath,
+		KeyName: "", // Empty — should default to "mykey"
+	}
+
+	signer, err := signing.NewRSASigner(cfg)
+	if err != nil {
+		t.Fatalf("NewRSASigner() error = %v", err)
+	}
+
+	ctx := context.Background()
+
+	err = signer.Sign(ctx, apkPath)
+	if err != nil {
+		t.Fatalf("Sign() error = %v", err)
+	}
+
+	// Verify the signature entry name contains "mykey"
+	signedData, err := os.ReadFile(apkPath)
+	if err != nil {
+		t.Fatalf("Failed to read signed APK: %v", err)
+	}
+
+	entryName, err := extractSignatureEntryName(t, signedData)
+	if err != nil {
+		t.Fatalf("Failed to extract entry name: %v", err)
+	}
+
+	if entryName != ".SIGN.RSA.mykey.rsa.pub" {
+		t.Errorf("Expected entry name '.SIGN.RSA.mykey.rsa.pub', got %q", entryName)
+	}
+}
+
+// extractSignatureEntryName extracts the entry name from the first tar entry.
+func extractSignatureEntryName(t *testing.T, apkData []byte) (string, error) {
+	t.Helper()
+
+	reader := bytes.NewReader(apkData)
+
+	gz, err := gzip.NewReader(reader)
+	if err != nil {
+		return "", err
+	}
+
+	defer func() {
+		_ = gz.Close()
+	}()
+
+	tr := tar.NewReader(gz)
+
+	hdr, err := tr.Next()
+	if err != nil {
+		return "", err
+	}
+
+	return hdr.Name, nil
+}

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -1,0 +1,73 @@
+// Package signing provides package signing infrastructure for YAP.
+//
+// This package establishes the foundation for signing packages across all
+// supported formats (APK, DEB, RPM, Pacman). It defines the Signer interface,
+// signing configuration, and resolution logic for keys and passphrases.
+//
+// Phase 0 (this phase) provides infrastructure only. Actual signing
+// implementations are added in Phase 3 (APK RSA) and Phase 4 (DEB/RPM/Pacman GPG).
+package signing
+
+import (
+	"context"
+)
+
+// Format identifies a package format that needs signing.
+type Format string
+
+const (
+	// FormatAPK represents Alpine Linux APK packages.
+	FormatAPK Format = "apk"
+	// FormatDEB represents Debian packages.
+	FormatDEB Format = "deb"
+	// FormatRPM represents Red Hat RPM packages.
+	FormatRPM Format = "rpm"
+	// FormatPacman represents Arch Linux Pacman packages.
+	FormatPacman Format = "pacman"
+)
+
+// Algorithm names a signing algorithm/key family.
+type Algorithm string
+
+const (
+	// AlgorithmRSA uses PKCS#1 v1.5 SHA1, used by APK.
+	AlgorithmRSA Algorithm = "rsa"
+	// AlgorithmGPG uses OpenPGP, used by DEB/RPM/Pacman.
+	AlgorithmGPG Algorithm = "gpg"
+)
+
+// Config holds resolved signing configuration for a build.
+type Config struct {
+	// Enabled indicates whether signing is active.
+	Enabled bool
+	// KeyPath is the resolved absolute path to the private key
+	// (PEM format for RSA, ASCII-armored for GPG).
+	KeyPath string
+	// Passphrase is the resolved passphrase, may be empty.
+	Passphrase string
+	// KeyName is optional, used for APK key naming (e.g., "mykey").
+	KeyName string
+}
+
+// Signer signs a package artifact in place or writes a detached signature.
+// Concrete implementations live in this package (RSA for APK, GPG for others).
+//
+// The behavior depends on the format:
+//   - APK: rebuilds the package with a third concatenated gzip stream
+//     containing .SIGN.RSA.<keyname>.rsa.pub (Phase 3)
+//   - DEB: appends _gpgorigin to the ar archive (dpkg-sig style) (Phase 4)
+//   - RPM: writes signature into the RPM lead/header (delegated to rpmpack) (Phase 4)
+//   - Pacman: writes detached <artifactPath>.sig (Phase 4)
+type Signer interface {
+	// Sign signs the artifact at artifactPath.
+	Sign(ctx context.Context, artifactPath string) error
+}
+
+// NoopSigner is returned when signing is disabled.
+// It implements Signer but performs no operation.
+type NoopSigner struct{}
+
+// Sign is a no-op implementation of the Signer interface.
+func (NoopSigner) Sign(_ context.Context, _ string) error {
+	return nil
+}

--- a/pkg/signing/signing_internal_test.go
+++ b/pkg/signing/signing_internal_test.go
@@ -1,0 +1,72 @@
+package signing
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for internal functions that need package-level access
+// These tests are in the signing package (not signing_test) to access unexported functions
+
+func TestResolveKeyPathPriority(t *testing.T) {
+	// Create temporary key files for testing
+	tmpDir := t.TempDir()
+	cliKeyPath := filepath.Join(tmpDir, "cli.key")
+	envKeyPath := filepath.Join(tmpDir, "env.key")
+	configKeyPath := filepath.Join(tmpDir, "config.key")
+
+	// Create the key files
+	for _, path := range []string{cliKeyPath, envKeyPath, configKeyPath} {
+		if err := os.WriteFile(path, []byte("test key"), 0o600); err != nil {
+			t.Fatalf("Failed to create test key file: %v", err)
+		}
+	}
+
+	// Test CLI flag takes priority
+	keyPath, err := resolveKeyPath(FormatDEB, cliKeyPath, configKeyPath)
+	require.NoError(t, err)
+	assert.Equal(t, cliKeyPath, keyPath)
+
+	// Test env var used when no CLI flag
+	keyPath, err = resolveKeyPath(FormatDEB, "", configKeyPath)
+	require.NoError(t, err)
+	// Should resolve to config key since no env var is set
+	assert.Equal(t, configKeyPath, keyPath)
+}
+
+func TestResolvePassphrasePriority(t *testing.T) {
+	// Test CLI flag takes priority
+	pass := resolvePassphrase(FormatDEB, "cli-pass", "config-pass")
+	assert.Equal(t, "cli-pass", pass)
+
+	// Test config used when no CLI flag
+	pass = resolvePassphrase(FormatDEB, "", "config-pass")
+	assert.Equal(t, "config-pass", pass)
+
+	// Test empty when neither provided
+	pass = resolvePassphrase(FormatDEB, "", "")
+	assert.Equal(t, "", pass)
+}
+
+func TestAlgorithmForFormat(t *testing.T) {
+	tests := []struct {
+		format    Format
+		algorithm Algorithm
+	}{
+		{FormatAPK, AlgorithmRSA},
+		{FormatDEB, AlgorithmGPG},
+		{FormatRPM, AlgorithmGPG},
+		{FormatPacman, AlgorithmGPG},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.format), func(t *testing.T) {
+			algo := algorithmForFormat(tt.format)
+			assert.Equal(t, tt.algorithm, algo)
+		})
+	}
+}

--- a/pkg/signing/signing_test.go
+++ b/pkg/signing/signing_test.go
@@ -1,0 +1,58 @@
+package signing_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/M0Rf30/yap/v2/pkg/signing"
+)
+
+func TestNewSignerDisabled(t *testing.T) {
+	cfg := signing.Config{
+		Enabled: false,
+		KeyPath: "",
+	}
+
+	signer, err := signing.NewSigner(signing.FormatDEB, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, signer)
+
+	// Noop signer should not error on Sign
+	ctx := context.Background()
+	err = signer.Sign(ctx, "/tmp/artifact")
+	assert.NoError(t, err)
+}
+
+func TestNewSignerEnabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "test.gpg")
+
+	// Create a minimal test key file
+	if err := os.WriteFile(keyPath, []byte("-----BEGIN PGP PRIVATE KEY BLOCK-----\n\n-----END PGP PRIVATE KEY BLOCK-----"), 0o600); err != nil {
+		t.Fatalf("Failed to create test key file: %v", err)
+	}
+
+	cfg := signing.Config{
+		Enabled: true,
+		KeyPath: keyPath,
+	}
+
+	// This will fail because the key is not valid, but it tests the path
+	_, err := signing.NewSigner(signing.FormatDEB, cfg)
+	assert.Error(t, err) // Expected to fail with invalid key
+}
+
+func TestNewSignerEnabledNoKey(t *testing.T) {
+	cfg := signing.Config{
+		Enabled: true,
+		KeyPath: "/nonexistent/key.gpg",
+	}
+
+	_, err := signing.NewSigner(signing.FormatDEB, cfg)
+	assert.Error(t, err) // Expected to fail with missing key
+}


### PR DESCRIPTION
Adopts five capabilities inspired by goreleaser/nfpm while preserving YAP's PKGBUILD-centric, container-isolated build model.

Signing (pkg/signing):
- APK: pure-Go RSA PKCS#1 v1.5 SHA1 over control.tar.gz, prepended as third concatenated gzip stream (.SIGN.RSA.<keyname>.rsa.pub). Enables `apk add` without --allow-untrusted.
- DEB/RPM/Pacman: OpenPGP via ProtonMail/go-crypto. DEB/RPM emit ASCII detached .asc sidecars; Pacman emits binary .sig matching makepkg --sign; RPM also exposes GetSigningFunction() for rpmpack.SetPGPSigner.
- Key resolution: CLI > format env > global env > yap.json > ~/.config/yap/keys/.

SBOM (pkg/sbom):
- Opt-in --sbom flag, hand-rolled CycloneDX 1.5 + SPDX 2.3 sidecars (.cdx.json/.spdx.json) emitted next to each artifact.

Per-format compression:
- --compression-deb and --compression-rpm flags accept zstd|gzip|xz. APK stays gzip and Pacman stays zstd (format-locked).

PKGBUILD additions (recipe-level):
- changelog field: DEB emits Lintian-compliant usr/share/doc/<pkg>/changelog.Debian.gz, Pacman emits .CHANGELOG; RPM deferred (rpmpack v0.7.1 API gap).
- Pacman .INSTALL: full 6-hook parity with DEB/RPM via new pre_upgrade and post_upgrade fields. .install only emitted when scriptlets exist.

Pipeline:
- Builder.BuildPackage now returns (string, error) so the build pipeline can address the produced artifact for post-build hooks (sign, SBOM).

Build-tool concerns (compression, signing, SBOM) live in CLI flags + yap.json (pkg/core/config.go), keeping PKGBUILD portable as a recipe format. Changelog and Pacman scriptlets are recipe concerns and live in PKGBUILD.