### PR TITLE
feat(mcp): publish yap-mcp to MCP registry + skill distribution

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,0 +1,111 @@
+name: 📡 Publish MCP Server
+
+# Builds the dedicated yap-mcp OCI image and publishes the server to the
+# official MCP registry (registry.modelcontextprotocol.io).
+#
+# Runs on version tags after release artifacts exist. The OCI image is the
+# package referenced by server.json (registryType: oci).
+
+on:
+  push:
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (without v prefix, e.g. 2.2.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write # required for MCP registry GitHub OIDC auth
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/m0rf30/yap-mcp
+
+jobs:
+  image:
+    name: 🐳 Build & push yap-mcp image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: 📂 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🏷️ Resolve version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            V="${{ github.event.inputs.version }}"
+          else
+            V="${GITHUB_REF#refs/tags/v}"
+          fi
+          echo "version=${V}" >> "$GITHUB_OUTPUT"
+
+      - name: 🔧 Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: 🔑 Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🐳 Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: build/mcp/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            VERSION=v${{ steps.ver.outputs.version }}
+            COMMIT=${{ github.sha }}
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.ver.outputs.version }}
+            ${{ env.IMAGE }}:latest
+
+  publish:
+    name: 📡 Publish to MCP registry
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: image
+    steps:
+      - name: 📂 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🏷️ Resolve version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            V="${{ github.event.inputs.version }}"
+          else
+            V="${GITHUB_REF#refs/tags/v}"
+          fi
+          echo "version=${V}" >> "$GITHUB_OUTPUT"
+
+      - name: 🔄 Inject tag version into server.json
+        run: |
+          V="${{ steps.ver.outputs.version }}"
+          # server.json ships with a 0.0.0 placeholder; the git tag is the
+          # single source of truth. Update server version + OCI package version.
+          jq --arg v "$V" \
+            '.version = $v | .packages[].version = $v' \
+            server.json > server.json.tmp
+          mv server.json.tmp server.json
+          cat server.json
+
+      - name: 📥 Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar -xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+
+      - name: 🔐 Authenticate (GitHub OIDC)
+        run: mcp-publisher login github-oidc
+
+      - name: 📡 Publish
+        run: mcp-publisher publish

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,90 @@
+# Publishing YAP's MCP server & skill
+
+This document covers how `yap-mcp` and the YAP agent skill are distributed to
+the popular discovery channels.
+
+## Artifacts
+
+| Artifact | Source | Channel |
+| --- | --- | --- |
+| `yap-mcp` binary | goreleaser (`.goreleaser.yml`, id `yap-mcp`) | GitHub Releases |
+| `ghcr.io/m0rf30/yap-mcp` OCI image | `build/mcp/Dockerfile` + `.github/workflows/mcp-publish.yml` | GHCR + MCP registry |
+| `server.json` | repo root | MCP registry manifest |
+| `skills/yap/SKILL.md` | repo | Anthropic Agent Skills layout |
+
+## 1. MCP Registry (registry.modelcontextprotocol.io)
+
+The official registry is the highest-signal channel. It cannot ingest a raw
+`.tar.gz` release asset — `registryType` only accepts `npm | pypi | oci |
+nuget | mcpb`. We publish the **OCI image** and reference it from
+`server.json`.
+
+Automated on every `v*.*.*` tag by `.github/workflows/mcp-publish.yml`:
+
+1. Builds + pushes `ghcr.io/m0rf30/yap-mcp:{version,latest}` (amd64 + arm64).
+2. Syncs the version into `server.json`.
+3. Authenticates via **GitHub OIDC** (`mcp-publisher login github-oidc`).
+4. `mcp-publisher publish`.
+
+Manual publish:
+
+```sh
+# from repo root, server.json present
+mcp-publisher login github-oidc
+mcp-publisher publish
+```
+
+Namespace `io.github.m0rf30/*` is owned automatically via the GitHub OIDC
+identity (the repo is under the `M0Rf30` GitHub account).
+
+### Naming
+
+- Server name: `io.github.m0rf30/yap` (reverse-DNS, exactly one `/`).
+- OCI image carries the `io.modelcontextprotocol.server.name` label so the
+  registry can verify ownership of the image ↔ server mapping.
+
+## 2. GitHub Releases (binaries)
+
+Already handled by `.goreleaser.yml` (`yap-mcp` build + per-binary archive).
+Users install via:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/M0Rf30/yap/main/scripts/install.sh | sh
+```
+
+This is the path for manual / direct client config (no container).
+
+## 3. Aggregators & awesome-lists (PR-based discovery)
+
+Submit once; they index from GitHub thereafter. Each wants the repo URL +
+`server.json` (or their own manifest):
+
+| Channel | How |
+| --- | --- |
+| `modelcontextprotocol/servers` (Community Servers) | PR adding a list entry |
+| `punkpeye/awesome-mcp-servers` | PR adding a list entry |
+| Glama (`glama.ai/mcp`) | auto-indexes public GitHub MCP repos |
+| PulseMCP (`pulsemcp.com`) | submission form |
+| mcp.so | submission form |
+| Smithery (`smithery.ai`) | add `smithery.yaml` (optional, for hosted deploy) |
+
+## 4. Agent Skill channels
+
+`skills/yap/SKILL.md` already follows the Anthropic Agent Skills layout.
+
+| Channel | How |
+| --- | --- |
+| This repo | canonical source (`skills/yap/`) |
+| `anthropics/skills` | PR to contribute as a community skill |
+| Claude Code plugin marketplaces | bundle skill in a plugin repo with `plugin.json` |
+| awesome-claude-skills lists | PR adding an entry |
+
+## Release checklist
+
+1. Tag `vX.Y.Z` → `release.yml` builds binaries, `mcp-publish.yml` builds the
+   OCI image and publishes to the MCP registry.
+2. Verify the image: `docker run -i --rm ghcr.io/m0rf30/yap-mcp:latest` (should
+   block on stdio).
+3. Verify the registry entry at
+   `https://registry.modelcontextprotocol.io/v0/servers?search=yap`.
+4. (First release only) open the aggregator + skill PRs above.

--- a/README.md
+++ b/README.md
@@ -283,17 +283,28 @@ over the [Model Context Protocol](https://modelcontextprotocol.io), so any
 MCP-compatible LLM client (Claude Desktop, opencode, Cursor, Zed, Continue,
 Goose, …) can drive yap directly.
 
-Quickstart:
+Quickstart (release binary):
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/M0Rf30/yap/main/scripts/install.sh | sh
 # then add { "mcpServers": { "yap": { "command": "yap-mcp" } } } to your client config
 ```
 
+Or pull the standalone OCI image (also listed on the
+[MCP registry](https://registry.modelcontextprotocol.io) as `io.github.m0rf30/yap`):
+
+```sh
+docker pull ghcr.io/m0rf30/yap-mcp:latest
+# client config:
+# { "mcpServers": { "yap": { "command": "docker",
+#   "args": ["run","-i","--rm","ghcr.io/m0rf30/yap-mcp:latest"] } } }
+```
+
 The full tool surface, per-client config snippets, security model, and
 troubleshooting are in **[`MCP.md`](MCP.md)**. The shipped skill card at
 [`skills/yap/SKILL.md`](skills/yap/SKILL.md) follows the Anthropic Agent
-Skills layout and gives agents a workflow cheatsheet for free.
+Skills layout and gives agents a workflow cheatsheet for free. Distribution
+channels and release steps are documented in **[`PUBLISHING.md`](PUBLISHING.md)**.
 
 ## CLI reference
 

--- a/build/mcp/Dockerfile
+++ b/build/mcp/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+# Minimal OCI image shipping only the yap-mcp stdio server.
+# Published as ghcr.io/m0rf30/yap-mcp and referenced by server.json for the
+# Model Context Protocol registry (registryType: oci).
+
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
+WORKDIR /src
+RUN apk add --no-cache git
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+# Cross-compile natively on the build platform (no QEMU). CGO is disabled, so
+# GOARCH switching is clean and needs no C toolchain.
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+ARG COMMIT=none
+ARG BUILD_TIME=unknown
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+    -ldflags "-s -w \
+      -X github.com/M0Rf30/yap/v2/pkg/buildinfo.Version=${VERSION} \
+      -X github.com/M0Rf30/yap/v2/pkg/buildinfo.Commit=${COMMIT} \
+      -X github.com/M0Rf30/yap/v2/pkg/buildinfo.BuildTime=${BUILD_TIME}" \
+    -o /out/yap-mcp ./cmd/yap-mcp
+
+FROM gcr.io/distroless/static-debian12:nonroot
+LABEL org.opencontainers.image.title="yap-mcp" \
+      org.opencontainers.image.description="MCP server exposing YAP package-build capabilities" \
+      org.opencontainers.image.source="https://github.com/M0Rf30/yap" \
+      org.opencontainers.image.vendor="M0Rf30" \
+      io.modelcontextprotocol.server.name="io.github.m0rf30/yap"
+COPY --from=build /out/yap-mcp /usr/local/bin/yap-mcp
+ENTRYPOINT ["/usr/local/bin/yap-mcp"]

--- a/examples/yap/PKGBUILD
+++ b/examples/yap/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=yap
-pkgver=2.0.0
+pkgver=2.2.2
 pkgrel=1
 pkgdesc="Package software with ease"
 pkgdesc__alpine="Package software with ease for Alpine"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.m0rf30/yap",
+  "title": "YAP — Yet Another Packager",
+  "description": "Build native Linux packages (.deb/.rpm/.apk/.pkg.tar.zst) from a single PKGBUILD via MCP.",
+  "version": "0.0.0",
+  "websiteUrl": "https://github.com/M0Rf30/yap",
+  "repository": {
+    "url": "https://github.com/M0Rf30/yap",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/m0rf30/yap-mcp",
+      "version": "0.0.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "YAP_VERBOSE",
+          "description": "Set to 1 for debug-level JSON-RPC frame logging on stderr.",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "tool": "yap-mcp",
+      "tools": [
+        "validate", "parse_pkgbuild", "graph", "build", "build_status",
+        "build_wait", "build_logs", "build_cancel", "list_artifacts",
+        "inspect", "install", "prepare", "pull", "zap", "list_distros",
+        "list_images", "resolve_distro", "status"
+      ],
+      "prompts": ["build_single_pkg", "cross_compile", "sign_and_release"],
+      "resources": ["yap://distros", "yap://pkgbuild/{path}"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds the missing pieces to publish `yap-mcp` and the YAP agent skill to popular channels.

## What's included
- **`server.json`** — MCP registry manifest (`io.github.m0rf30/yap`, OCI package, stdio transport, full tool/prompt/resource metadata)
- **`build/mcp/Dockerfile`** — dedicated distroless `yap-mcp` image (the artifact the registry pulls; carries `io.modelcontextprotocol.server.name` ownership label)
- **`.github/workflows/mcp-publish.yml`** — on `v*.*.*` tags: build+push multi-arch OCI image to GHCR, sync version into `server.json`, publish to the MCP registry via **GitHub OIDC** (no secrets)
- **`README.md`** — OCI/registry install option alongside the existing binary quickstart
- **`PUBLISHING.md`** — channel matrix (registry, aggregators, skill repos) + release checklist

## Why OCI when release binaries exist
Release binaries remain the manual-install path (`install.sh` → `yap-mcp`). The official registry can't ingest a raw `.tar.gz` (`registryType` ∈ `npm|pypi|oci|nuget|mcpb`), so the registry entry wraps the same server in an OCI image. Both coexist.

## Follow-up (one-time, manual — documented in PUBLISHING.md)
- Aggregator PRs: `modelcontextprotocol/servers`, `punkpeye/awesome-mcp-servers`, Glama, PulseMCP, mcp.so
- Skill: `anthropics/skills` + Claude Code plugin marketplaces

## Notes
- No code changes; docs + CI + manifest only.
- `examples/yap/PKGBUILD` left untouched (pre-existing working-tree change excluded).