### PR TITLE
feat(mcp): Claude Code plugin + Smithery distribution

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "yap",
+  "version": "0.0.0",
+  "description": "Build native Linux packages (.deb/.rpm/.apk/.pkg.tar.zst) from a single PKGBUILD. Bundles the yap-mcp server and the yap agent skill.",
+  "author": {
+    "name": "M0Rf30",
+    "url": "https://github.com/M0Rf30"
+  },
+  "homepage": "https://github.com/M0Rf30/yap",
+  "repository": "https://github.com/M0Rf30/yap",
+  "license": "GPL-3.0-only",
+  "keywords": ["packaging", "deb", "rpm", "apk", "pacman", "pkgbuild", "linux"],
+  "mcpServers": {
+    "yap": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "ghcr.io/m0rf30/yap-mcp:latest"]
+    }
+  }
+}

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -112,3 +112,46 @@ jobs:
 
       - name: 📡 Publish
         run: mcp-publisher publish
+
+  # Bump the Claude Code plugin manifest version to match the tag and commit it
+  # back to the default branch. plugin.json is read from the repo at install
+  # time, so unlike server.json it must be persisted (not just injected in CI).
+  plugin-version:
+    name: 🔖 Sync plugin.json version
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: image
+    permissions:
+      contents: write
+    steps:
+      - name: 📂 Checkout default branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: 🏷️ Resolve version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            V="${{ github.event.inputs.version }}"
+          else
+            V="${GITHUB_REF#refs/tags/v}"
+          fi
+          echo "version=${V}" >> "$GITHUB_OUTPUT"
+
+      - name: 🔖 Update & commit plugin.json
+        run: |
+          V="${{ steps.ver.outputs.version }}"
+          jq --arg v "$V" '.version = $v' \
+            .claude-plugin/plugin.json > .claude-plugin/plugin.json.tmp
+          mv .claude-plugin/plugin.json.tmp .claude-plugin/plugin.json
+          if git diff --quiet; then
+            echo "plugin.json already at ${V}"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/plugin.json
+          git commit -m "chore(plugin): sync plugin.json version to ${V} [skip ci]"
+          git push

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -70,23 +70,52 @@ Submit once; they index from GitHub thereafter. Each wants the repo URL +
 | mcp.so | submission form |
 | Smithery (`smithery.ai`) | add `smithery.yaml` (optional, for hosted deploy) |
 
-## 4. Agent Skill channels
+## 4. Claude Code plugin (server + skill bundle)
 
-`skills/yap/SKILL.md` already follows the Anthropic Agent Skills layout.
+`.claude-plugin/plugin.json` in this repo bundles the `yap-mcp` MCP server and
+auto-discovers the `skills/yap/` skill. It is listed from a dedicated
+**org-level marketplace repo** (`M0Rf30/claude-plugins`) so all M0Rf30 tools
+share one namespace.
+
+```text
+/plugin marketplace add M0Rf30/claude-plugins
+/plugin install yap@M0Rf30
+```
+
+- `M0Rf30/claude-plugins/.claude-plugin/marketplace.json` lists the `yap` plugin
+  with `source: { github, repo: M0Rf30/yap }` (optionally pin `ref` to a tag).
+- This repo ships only `plugin.json` (no `marketplace.json`).
+- `plugin.json` version is `0.0.0` in-repo; the `mcp-publish.yml`
+  `plugin-version` job bumps it to the tag and commits it back on release
+  (plugin.json is read from the repo at install time, so it must be persisted).
+
+## 5. Smithery
+
+`smithery.yaml` defines a stdio start command launching
+`ghcr.io/m0rf30/yap-mcp:latest` plus a hosted-build block. Users:
+
+```sh
+npx @smithery/cli install io.github.M0Rf30/yap --client claude
+```
+
+## 6. Agent Skill channels
+
+`skills/yap/SKILL.md` follows the Anthropic Agent Skills layout.
 
 | Channel | How |
 | --- | --- |
 | This repo | canonical source (`skills/yap/`) |
+| Claude Code plugin | bundled via `M0Rf30/claude-plugins` (above) |
 | `anthropics/skills` | PR to contribute as a community skill |
-| Claude Code plugin marketplaces | bundle skill in a plugin repo with `plugin.json` |
 | awesome-claude-skills lists | PR adding an entry |
 
 ## Release checklist
 
 1. Tag `vX.Y.Z` → `release.yml` builds binaries, `mcp-publish.yml` builds the
-   OCI image and publishes to the MCP registry.
+   OCI image, publishes to the MCP registry, and bumps `plugin.json`.
 2. Verify the image: `docker run -i --rm ghcr.io/m0rf30/yap-mcp:latest` (should
    block on stdio).
 3. Verify the registry entry at
    `https://registry.modelcontextprotocol.io/v0/servers?search=yap`.
-4. (First release only) open the aggregator + skill PRs above.
+4. (First release only) create the `M0Rf30/claude-plugins` repo and open the
+   aggregator + skill PRs above.

--- a/README.md
+++ b/README.md
@@ -300,6 +300,19 @@ docker pull ghcr.io/m0rf30/yap-mcp:latest
 #   "args": ["run","-i","--rm","ghcr.io/m0rf30/yap-mcp:latest"] } } }
 ```
 
+### Claude Code plugin (server + skill in one)
+
+```text
+/plugin marketplace add M0Rf30/claude-plugins
+/plugin install yap@M0Rf30
+```
+
+### Smithery
+
+```sh
+npx @smithery/cli install io.github.M0Rf30/yap --client claude
+```
+
 The full tool surface, per-client config snippets, security model, and
 troubleshooting are in **[`MCP.md`](MCP.md)**. The shipped skill card at
 [`skills/yap/SKILL.md`](skills/yap/SKILL.md) follows the Anthropic Agent

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,28 @@
+# Smithery configuration for the yap-mcp server.
+# https://smithery.ai/docs/build/project-config
+#
+# yap-mcp speaks stdio. We launch the published multi-arch OCI image so users
+# don't need a local Go toolchain.
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      verbose:
+        type: boolean
+        title: Verbose logging
+        description: Emit debug-level JSON-RPC frame logging on stderr.
+        default: false
+    additionalProperties: false
+  commandFunction: |-
+    (config) => ({
+      command: "docker",
+      args: ["run", "-i", "--rm",
+             ...(config.verbose ? ["-e", "YAP_VERBOSE=1"] : []),
+             "ghcr.io/m0rf30/yap-mcp:latest"]
+    })
+
+build:
+  dockerfile: build/mcp/Dockerfile
+  dockerBuildPath: .


### PR DESCRIPTION
## Summary
Adds marketplace-based distribution for the `yap-mcp` server + skill.

## Changes (this repo)
- **`.claude-plugin/plugin.json`** — bundles the `yap-mcp` MCP server (Docker) and auto-discovers the existing `skills/yap/` skill.
- **`smithery.yaml`** — stdio start command launching `ghcr.io/m0rf30/yap-mcp:latest` (+ `verbose` toggle) and a hosted-build block pointing at `build/mcp/Dockerfile`.
- **`mcp-publish.yml`** — new `plugin-version` job bumps `plugin.json` to the tag and commits it back to the default branch (plugin.json is read from the repo at install time, so it must be persisted; `0.0.0` sentinel in-repo).
- **README / PUBLISHING** — marketplace + Smithery install docs.

## User install
```
/plugin marketplace add M0Rf30/claude-plugins
/plugin install yap@M0Rf30
```
```
npx @smithery/cli install io.github.M0Rf30/yap --client claude
```

## Out-of-repo follow-up (manual)
The org marketplace lives in a **separate repo** so the `M0Rf30` namespace is shared across tools. I generated its contents locally at `../claude-plugins/` (`.claude-plugin/marketplace.json` + README) — create `M0Rf30/claude-plugins` on GitHub and push them. This repo intentionally ships only `plugin.json` (no `marketplace.json`).

## Notes
- Docker build caveat unchanged: container is ideal for read-only tools; actual package builds need the binary or a docker-socket mount.