### PR TITLE
fix(builders): guard RPM release suffix against double-append for split packages

### DIFF
--- a/pkg/builders/common/interface.go
+++ b/pkg/builders/common/interface.go
@@ -245,9 +245,11 @@ func (bb *BaseBuilder) LogPackageCreated(artifactPath string) {
 
 // FormatRelease formats the package release string with distribution-specific suffixes.
 // For DEB packages: always appends a distro suffix (codename or distro name) for proper
-// repository targeting. The suffix is guarded against double-append for split packages.
-// For RPM packages: appends RPM distro suffix and codename (only when codename is set)
-// For other formats: returns release unchanged
+// repository targeting.
+// For RPM packages: appends RPM distro suffix and codename (only when codename is set).
+// For other formats: returns release unchanged.
+// All appends are guarded against double-append so the method stays idempotent when
+// called once per sub-package of a split PKGBUILD sharing the same state (issue #218).
 func (bb *BaseBuilder) FormatRelease(distroSuffixMap map[string]string) {
 	switch bb.Format {
 	case formatDeb:
@@ -270,7 +272,11 @@ func (bb *BaseBuilder) FormatRelease(distroSuffixMap map[string]string) {
 		}
 
 		if suffix, exists := distroSuffixMap[bb.PKGBUILD.Distro]; exists {
-			bb.PKGBUILD.PkgRel += suffix + bb.PKGBUILD.Codename
+			full := suffix + bb.PKGBUILD.Codename
+			// Guard against double-append when called multiple times for split packages
+			if !strings.HasSuffix(bb.PKGBUILD.PkgRel, full) {
+				bb.PKGBUILD.PkgRel += full
+			}
 		}
 	}
 }

--- a/pkg/builders/common/interface_extra_test.go
+++ b/pkg/builders/common/interface_extra_test.go
@@ -98,6 +98,41 @@ func TestFormatRelease_RPM_UnknownDistro_NoChange(t *testing.T) {
 	}
 }
 
+// Regression test for issue #218: split packages call FormatRelease once per
+// sub-package on shared PKGBUILD state; the RPM suffix must not double up.
+func TestFormatRelease_RPM_Idempotent(t *testing.T) {
+	bb := newBuilder(t, constants.FormatRPM, func(p *pkgbuild.PKGBUILD) {
+		p.PkgRel = "1"
+		p.Codename = "el9"
+		p.Distro = "rocky"
+	})
+
+	suffixMap := map[string]string{"rocky": "."}
+
+	bb.FormatRelease(suffixMap)
+	bb.FormatRelease(suffixMap)
+
+	want := "1.el9"
+	if bb.PKGBUILD.PkgRel != want {
+		t.Errorf("PkgRel = %q after repeated FormatRelease, want %q", bb.PKGBUILD.PkgRel, want)
+	}
+}
+
+func TestFormatRelease_DEB_Idempotent(t *testing.T) {
+	bb := newBuilder(t, constants.FormatDEB, func(p *pkgbuild.PKGBUILD) {
+		p.PkgRel = "1"
+		p.Codename = "jammy"
+	})
+
+	bb.FormatRelease(map[string]string{})
+	bb.FormatRelease(map[string]string{})
+
+	want := "1jammy"
+	if bb.PKGBUILD.PkgRel != want {
+		t.Errorf("PkgRel = %q after repeated FormatRelease, want %q", bb.PKGBUILD.PkgRel, want)
+	}
+}
+
 func TestFormatRelease_APK_NoChange(t *testing.T) {
 	bb := newBuilder(t, constants.FormatAPK, func(p *pkgbuild.PKGBUILD) {
 		p.PkgRel = "1"


### PR DESCRIPTION
## Summary

`BaseBuilder.FormatRelease` mutates `PkgRel` in place and is invoked once per sub-package of a split PKGBUILD on shared state, so the second and subsequent RPM sub-packages got the distro suffix doubled (`1.el9.el9`). This mirrors the existing DEB idempotency guard on the RPM path: append `suffix+codename` only when `PkgRel` does not already end with it.

## Testing

- Added `TestFormatRelease_RPM_Idempotent` (regression for #218) and `TestFormatRelease_DEB_Idempotent`
- `go test -p 1 ./pkg/builders/common ./pkg/builders/rpm ./pkg/builders/deb` — pass
- `go vet ./pkg/builders/common` — clean

Fixes #218